### PR TITLE
fix: Replace git-cliff-action with manual install (Debian Buster EOL)

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -128,14 +128,19 @@ jobs:
         if: steps.check.outputs.should_release == 'true'
         run: cargo update -p rustyiam --precise ${{ steps.version.outputs.new_version }}
 
+      - name: Install git-cliff
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          wget https://github.com/orhun/git-cliff/releases/download/v2.4.0/git-cliff-2.4.0-x86_64-unknown-linux-gnu.tar.gz
+          tar -xzf git-cliff-2.4.0-x86_64-unknown-linux-gnu.tar.gz
+          sudo mv git-cliff-2.4.0/git-cliff /usr/local/bin/
+          git-cliff --version
+
       - name: Generate changelog
         if: steps.check.outputs.should_release == 'true'
-        uses: orhun/git-cliff-action@v3
-        with:
-          config: cliff.toml
-          args: --tag "v${{ steps.version.outputs.new_version }}"
-        env:
-          OUTPUT: CHANGELOG.md
+        run: |
+          NEW_VERSION="${{ steps.version.outputs.new_version }}"
+          git-cliff --config cliff.toml --tag "v$NEW_VERSION" --output CHANGELOG.md
 
       - name: Commit and tag
         if: steps.check.outputs.should_release == 'true'


### PR DESCRIPTION
## Problem

The `orhun/git-cliff-action@v3` action fails to build because it uses a Docker image based on **Debian Buster**, which reached End of Life in August 2022. The apt repositories are no longer available, causing this error:

```
E: The repository 'http://deb.debian.org/debian buster Release' does not have a Release file.
```

The action tries to install `jq` during the Docker build but fails because the Debian repos are gone.

## Solution

This PR replaces the git-cliff-action with a **manual installation** of the git-cliff binary:

- Downloads the pre-compiled binary directly from GitHub releases
- Extracts and installs it to `/usr/local/bin/`
- Runs git-cliff command directly
- **No Docker or Debian dependencies** needed

## Changes

- ❌ Removed: `uses: orhun/git-cliff-action@v3`
- ✅ Added: Manual download and installation of git-cliff v2.4.0
- ✅ Added: Direct execution of git-cliff CLI

## Benefits

- 🚀 Faster execution (no Docker build required)
- 🔒 More reliable (no external OS dependency)
- 🛠️ Same functionality maintained

## Testing

This approach was working in our initial implementation and is the standard way to install git-cliff in CI environments.