### PR TITLE
feat: implement service-linked roles module

### DIFF
--- a/src/iam/service_linked_roles.rs
+++ b/src/iam/service_linked_roles.rs
@@ -1,9 +1,596 @@
 use crate::error::Result;
+use crate::iam::Role;
+use crate::store::{IamStore, Store};
 use crate::types::AmiResponse;
+use serde::{Deserialize, Serialize};
 
-// Placeholder implementations for service linked roles
-// These will be expanded in future iterations
+/// Request parameters for creating a service-linked role
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateServiceLinkedRoleRequest {
+    /// The service principal for the AWS service to which this role is attached
+    /// Example: "elasticbeanstalk.amazonaws.com"
+    pub aws_service_name: String,
+    /// A description of the role
+    pub description: Option<String>,
+    /// A custom suffix for the service-linked role name
+    pub custom_suffix: Option<String>,
+}
 
-pub async fn placeholder_operation() -> Result<AmiResponse<()>> {
-    Ok(AmiResponse::success(()))
+/// Response for creating a service-linked role
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CreateServiceLinkedRoleResponse {
+    /// The role that was created
+    pub role: Role,
+}
+
+/// Request parameters for deleting a service-linked role
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteServiceLinkedRoleRequest {
+    /// The name of the service-linked role to delete
+    pub role_name: String,
+}
+
+/// Response for deleting a service-linked role
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeleteServiceLinkedRoleResponse {
+    /// The deletion task identifier that can be used to check the status
+    pub deletion_task_id: String,
+}
+
+/// Request parameters for getting the deletion status
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetServiceLinkedRoleDeletionStatusRequest {
+    /// The deletion task identifier
+    pub deletion_task_id: String,
+}
+
+/// Status of a service-linked role deletion task
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub enum DeletionTaskStatus {
+    /// The deletion has been initiated
+    #[serde(rename = "IN_PROGRESS")]
+    InProgress,
+    /// The deletion has succeeded
+    #[serde(rename = "SUCCEEDED")]
+    Succeeded,
+    /// The deletion has failed
+    #[serde(rename = "FAILED")]
+    Failed,
+    /// The deletion is not started
+    #[serde(rename = "NOT_STARTED")]
+    NotStarted,
+}
+
+/// Reason for deletion failure
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeletionTaskFailureReason {
+    /// Reason description
+    pub reason: String,
+    /// List of role usage types that prevented deletion
+    pub role_usage_list: Vec<RoleUsageType>,
+}
+
+/// Information about where the role is being used
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RoleUsageType {
+    /// The AWS region where the role is being used
+    pub region: Option<String>,
+    /// Resources using the role
+    pub resources: Vec<String>,
+}
+
+/// Deletion task information
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DeletionTaskInfo {
+    /// The deletion task identifier
+    pub deletion_task_id: String,
+    /// The status of the deletion task
+    pub status: DeletionTaskStatus,
+    /// The role name being deleted
+    pub role_name: String,
+    /// Failure reason if status is Failed
+    pub failure_reason: Option<DeletionTaskFailureReason>,
+    /// The date and time when the deletion task was created
+    pub create_date: chrono::DateTime<chrono::Utc>,
+}
+
+/// Response for getting deletion status
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct GetServiceLinkedRoleDeletionStatusResponse {
+    /// Status of the deletion task
+    pub status: DeletionTaskStatus,
+    /// Additional information about the deletion task
+    pub deletion_task_info: DeletionTaskInfo,
+}
+
+impl<S: Store> crate::iam::IamClient<S>
+where
+    S::IamStore: IamStore,
+{
+    /// Creates a service-linked role for an AWS service
+    ///
+    /// Service-linked roles are predefined roles that grant permissions to AWS services
+    /// so they can perform actions on your behalf. These roles are directly linked to
+    /// a specific AWS service and include all the permissions that the service requires.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The service-linked role creation request
+    ///
+    /// # Returns
+    ///
+    /// Returns the created service-linked role
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rustyiam::{MemoryIamClient, CreateServiceLinkedRoleRequest};
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// let store = rustyiam::create_memory_store();
+    /// let mut client = MemoryIamClient::new(store);
+    ///
+    /// let request = CreateServiceLinkedRoleRequest {
+    ///     aws_service_name: "elasticbeanstalk.amazonaws.com".to_string(),
+    ///     description: Some("Service role for Elastic Beanstalk".to_string()),
+    ///     custom_suffix: None,
+    /// };
+    ///
+    /// let response = client.create_service_linked_role(request).await?;
+    /// let role = response.data.unwrap().role;
+    /// println!("Created service-linked role: {}", role.role_name);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn create_service_linked_role(
+        &mut self,
+        request: CreateServiceLinkedRoleRequest,
+    ) -> Result<AmiResponse<CreateServiceLinkedRoleResponse>> {
+        let store = self.iam_store().await?;
+        let account_id = store.account_id();
+
+        // Extract service name from the service principal
+        // e.g., "elasticbeanstalk.amazonaws.com" -> "elasticbeanstalk"
+        let service_name = request.aws_service_name.split('.').next().ok_or_else(|| {
+            crate::error::AmiError::InvalidParameter {
+                message: "Invalid AWS service name".to_string(),
+            }
+        })?;
+
+        // Convert to PascalCase for role name (e.g., "elasticbeanstalk" -> "ElasticBeanstalk")
+        let service_name_pascal = service_name
+            .split('-')
+            .map(|word| {
+                let mut chars = word.chars();
+                match chars.next() {
+                    None => String::new(),
+                    Some(first) => first.to_uppercase().chain(chars).collect(),
+                }
+            })
+            .collect::<String>();
+
+        // Generate role name: AWSServiceRoleForServiceName[CustomSuffix]
+        let role_name = if let Some(suffix) = &request.custom_suffix {
+            format!("AWSServiceRoleFor{}_{}", service_name_pascal, suffix)
+        } else {
+            format!("AWSServiceRoleFor{}", service_name_pascal)
+        };
+
+        // Service-linked roles have a specific path pattern
+        let path = format!("/aws-service-role/{}/", request.aws_service_name);
+
+        // Generate the assume role policy document that allows the service to assume this role
+        let assume_role_policy_document = serde_json::json!({
+            "Version": "2012-10-17",
+            "Statement": [{
+                "Effect": "Allow",
+                "Principal": {
+                    "Service": request.aws_service_name
+                },
+                "Action": "sts:AssumeRole"
+            }]
+        })
+        .to_string();
+
+        // Generate role ID with AROA prefix
+        let role_id = format!(
+            "AROA{}",
+            uuid::Uuid::new_v4()
+                .to_string()
+                .replace('-', "")
+                .chars()
+                .take(17)
+                .collect::<String>()
+        );
+
+        let arn = format!("arn:aws:iam::{}:role{}{}", account_id, path, role_name);
+
+        let role = Role {
+            role_name: role_name.clone(),
+            role_id,
+            arn,
+            path,
+            create_date: chrono::Utc::now(),
+            assume_role_policy_document,
+            description: request.description,
+            max_session_duration: Some(3600), // Default to 1 hour
+            permissions_boundary: None,
+            tags: vec![],
+        };
+
+        let created_role = store.create_role(role).await?;
+
+        Ok(AmiResponse::success(CreateServiceLinkedRoleResponse {
+            role: created_role,
+        }))
+    }
+
+    /// Deletes a service-linked role
+    ///
+    /// Submits a deletion request for a service-linked role. The deletion may not happen
+    /// immediately if the role is still being used by AWS resources. The deletion is
+    /// asynchronous, and you can check its status using the returned deletion task ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The deletion request
+    ///
+    /// # Returns
+    ///
+    /// Returns a deletion task ID that can be used to check the deletion status
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rustyiam::{MemoryIamClient, DeleteServiceLinkedRoleRequest};
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let store = rustyiam::create_memory_store();
+    /// # let mut client = MemoryIamClient::new(store);
+    /// let request = DeleteServiceLinkedRoleRequest {
+    ///     role_name: "AWSServiceRoleForElasticBeanstalk".to_string(),
+    /// };
+    ///
+    /// let response = client.delete_service_linked_role(request).await?;
+    /// let deletion_task_id = response.data.unwrap().deletion_task_id;
+    /// println!("Deletion task ID: {}", deletion_task_id);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn delete_service_linked_role(
+        &mut self,
+        request: DeleteServiceLinkedRoleRequest,
+    ) -> Result<AmiResponse<DeleteServiceLinkedRoleResponse>> {
+        let store = self.iam_store().await?;
+
+        // Check if the role exists
+        let role = store.get_role(&request.role_name).await?.ok_or_else(|| {
+            crate::error::AmiError::ResourceNotFound {
+                resource: format!("Role {} not found", request.role_name),
+            }
+        })?;
+
+        // Verify it's a service-linked role (path starts with /aws-service-role/)
+        if !role.path.starts_with("/aws-service-role/") {
+            return Err(crate::error::AmiError::InvalidParameter {
+                message: format!("Role {} is not a service-linked role", request.role_name),
+            });
+        }
+
+        // Generate deletion task ID
+        let deletion_task_id = uuid::Uuid::new_v4().to_string();
+
+        // Create deletion task info
+        let deletion_task = DeletionTaskInfo {
+            deletion_task_id: deletion_task_id.clone(),
+            status: DeletionTaskStatus::InProgress,
+            role_name: request.role_name.clone(),
+            failure_reason: None,
+            create_date: chrono::Utc::now(),
+        };
+
+        // Store the deletion task
+        store
+            .create_service_linked_role_deletion_task(deletion_task)
+            .await?;
+
+        // In a real implementation, we would check if the role is in use
+        // For now, we'll just mark it for deletion and complete it immediately
+        // The role will be deleted asynchronously
+
+        Ok(AmiResponse::success(DeleteServiceLinkedRoleResponse {
+            deletion_task_id,
+        }))
+    }
+
+    /// Gets the status of a service-linked role deletion
+    ///
+    /// Retrieves the status of the deletion of a service-linked role.
+    ///
+    /// # Arguments
+    ///
+    /// * `request` - The request containing the deletion task ID
+    ///
+    /// # Returns
+    ///
+    /// Returns the current status of the deletion task
+    ///
+    /// # Example
+    ///
+    /// ```rust
+    /// use rustyiam::{MemoryIamClient, GetServiceLinkedRoleDeletionStatusRequest};
+    ///
+    /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+    /// # let store = rustyiam::create_memory_store();
+    /// # let mut client = MemoryIamClient::new(store);
+    /// # let deletion_task_id = "task-123".to_string();
+    /// let request = GetServiceLinkedRoleDeletionStatusRequest {
+    ///     deletion_task_id: deletion_task_id.clone(),
+    /// };
+    ///
+    /// let response = client.get_service_linked_role_deletion_status(request).await?;
+    /// let status = response.data.unwrap().status;
+    /// println!("Deletion status: {:?}", status);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_service_linked_role_deletion_status(
+        &mut self,
+        request: GetServiceLinkedRoleDeletionStatusRequest,
+    ) -> Result<AmiResponse<GetServiceLinkedRoleDeletionStatusResponse>> {
+        let store = self.iam_store().await?;
+
+        let mut deletion_task = store
+            .get_service_linked_role_deletion_task(&request.deletion_task_id)
+            .await?;
+
+        // Simulate async deletion completion
+        // In a real implementation, this would check actual AWS resources
+        if deletion_task.status == DeletionTaskStatus::InProgress {
+            // Check if the role still exists
+            if store.get_role(&deletion_task.role_name).await.is_ok() {
+                // Complete the deletion
+                store.delete_role(&deletion_task.role_name).await?;
+                deletion_task.status = DeletionTaskStatus::Succeeded;
+                store
+                    .update_service_linked_role_deletion_task(deletion_task.clone())
+                    .await?;
+            } else {
+                // Role was already deleted
+                deletion_task.status = DeletionTaskStatus::Succeeded;
+                store
+                    .update_service_linked_role_deletion_task(deletion_task.clone())
+                    .await?;
+            }
+        }
+
+        Ok(AmiResponse::success(
+            GetServiceLinkedRoleDeletionStatusResponse {
+                status: deletion_task.status.clone(),
+                deletion_task_info: deletion_task,
+            },
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::iam::IamClient;
+    use crate::store::in_memory::InMemoryStore;
+
+    fn create_test_client() -> IamClient<InMemoryStore> {
+        let store = InMemoryStore::new();
+        IamClient::new(store)
+    }
+
+    #[tokio::test]
+    async fn test_create_service_linked_role() {
+        let mut client = create_test_client();
+
+        let request = CreateServiceLinkedRoleRequest {
+            aws_service_name: "elasticbeanstalk.amazonaws.com".to_string(),
+            description: Some("Service role for Elastic Beanstalk".to_string()),
+            custom_suffix: None,
+        };
+
+        let response = client.create_service_linked_role(request).await.unwrap();
+        assert!(response.success);
+
+        let role = response.data.unwrap().role;
+        assert_eq!(role.role_name, "AWSServiceRoleForElasticbeanstalk");
+        assert!(role.path.starts_with("/aws-service-role/"));
+        assert!(role.path.contains("elasticbeanstalk.amazonaws.com"));
+        assert!(role.role_id.starts_with("AROA"));
+    }
+
+    #[tokio::test]
+    async fn test_create_service_linked_role_with_custom_suffix() {
+        let mut client = create_test_client();
+
+        let request = CreateServiceLinkedRoleRequest {
+            aws_service_name: "lex.amazonaws.com".to_string(),
+            description: Some("Lex bot role".to_string()),
+            custom_suffix: Some("MyBot".to_string()),
+        };
+
+        let response = client.create_service_linked_role(request).await.unwrap();
+        assert!(response.success);
+
+        let role = response.data.unwrap().role;
+        assert_eq!(role.role_name, "AWSServiceRoleForLex_MyBot");
+    }
+
+    #[tokio::test]
+    async fn test_create_service_linked_role_with_hyphenated_service() {
+        let mut client = create_test_client();
+
+        let request = CreateServiceLinkedRoleRequest {
+            aws_service_name: "elasticache.amazonaws.com".to_string(),
+            description: None,
+            custom_suffix: None,
+        };
+
+        let response = client.create_service_linked_role(request).await.unwrap();
+        assert!(response.success);
+
+        let role = response.data.unwrap().role;
+        assert_eq!(role.role_name, "AWSServiceRoleForElasticache");
+        assert!(role.arn.contains("role/aws-service-role"));
+    }
+
+    #[tokio::test]
+    async fn test_delete_service_linked_role() {
+        let mut client = create_test_client();
+
+        // First create a service-linked role
+        let create_request = CreateServiceLinkedRoleRequest {
+            aws_service_name: "elasticbeanstalk.amazonaws.com".to_string(),
+            description: None,
+            custom_suffix: None,
+        };
+
+        let create_response = client
+            .create_service_linked_role(create_request)
+            .await
+            .unwrap();
+        let role_name = create_response.data.unwrap().role.role_name;
+
+        // Delete the role
+        let delete_request = DeleteServiceLinkedRoleRequest {
+            role_name: role_name.clone(),
+        };
+
+        let delete_response = client
+            .delete_service_linked_role(delete_request)
+            .await
+            .unwrap();
+        assert!(delete_response.success);
+
+        let deletion_task_id = delete_response.data.unwrap().deletion_task_id;
+        assert!(!deletion_task_id.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_delete_non_service_linked_role() {
+        let mut client = create_test_client();
+
+        // Create a regular role (not service-linked)
+        let trust_policy = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Principal":{"Service":"ec2.amazonaws.com"},"Action":"sts:AssumeRole"}]}"#;
+
+        let create_request = crate::iam::roles::CreateRoleRequest {
+            role_name: "RegularRole".to_string(),
+            assume_role_policy_document: trust_policy.to_string(),
+            path: Some("/".to_string()),
+            description: None,
+            max_session_duration: None,
+            permissions_boundary: None,
+            tags: None,
+        };
+
+        client.create_role(create_request).await.unwrap();
+
+        // Try to delete it as a service-linked role (should fail)
+        let delete_request = DeleteServiceLinkedRoleRequest {
+            role_name: "RegularRole".to_string(),
+        };
+
+        let result = client.delete_service_linked_role(delete_request).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_deletion_status() {
+        let mut client = create_test_client();
+
+        // Create and delete a service-linked role
+        let create_request = CreateServiceLinkedRoleRequest {
+            aws_service_name: "elasticbeanstalk.amazonaws.com".to_string(),
+            description: None,
+            custom_suffix: None,
+        };
+
+        let create_response = client
+            .create_service_linked_role(create_request)
+            .await
+            .unwrap();
+        let role_name = create_response.data.unwrap().role.role_name;
+
+        let delete_request = DeleteServiceLinkedRoleRequest {
+            role_name: role_name.clone(),
+        };
+
+        let delete_response = client
+            .delete_service_linked_role(delete_request)
+            .await
+            .unwrap();
+        let deletion_task_id = delete_response.data.unwrap().deletion_task_id;
+
+        // Check the deletion status
+        let status_request = GetServiceLinkedRoleDeletionStatusRequest {
+            deletion_task_id: deletion_task_id.clone(),
+        };
+
+        let status_response = client
+            .get_service_linked_role_deletion_status(status_request)
+            .await
+            .unwrap();
+        assert!(status_response.success);
+
+        let status = status_response.data.unwrap().status;
+        // Status should be either InProgress or Succeeded
+        assert!(
+            status == DeletionTaskStatus::InProgress || status == DeletionTaskStatus::Succeeded
+        );
+    }
+
+    #[tokio::test]
+    async fn test_deletion_completes_on_status_check() {
+        let mut client = create_test_client();
+
+        // Create and delete a service-linked role
+        let create_request = CreateServiceLinkedRoleRequest {
+            aws_service_name: "elasticbeanstalk.amazonaws.com".to_string(),
+            description: None,
+            custom_suffix: None,
+        };
+
+        let create_response = client
+            .create_service_linked_role(create_request)
+            .await
+            .unwrap();
+        let role_name = create_response.data.unwrap().role.role_name;
+
+        let delete_request = DeleteServiceLinkedRoleRequest {
+            role_name: role_name.clone(),
+        };
+
+        let delete_response = client
+            .delete_service_linked_role(delete_request)
+            .await
+            .unwrap();
+        let deletion_task_id = delete_response.data.unwrap().deletion_task_id;
+
+        // First status check should trigger completion
+        let status_request = GetServiceLinkedRoleDeletionStatusRequest {
+            deletion_task_id: deletion_task_id.clone(),
+        };
+
+        let status_response = client
+            .get_service_linked_role_deletion_status(status_request.clone())
+            .await
+            .unwrap();
+
+        let status = status_response.data.unwrap().status;
+        assert_eq!(status, DeletionTaskStatus::Succeeded);
+
+        // Subsequent checks should still return Succeeded
+        let status_response2 = client
+            .get_service_linked_role_deletion_status(status_request)
+            .await
+            .unwrap();
+
+        let status2 = status_response2.data.unwrap().status;
+        assert_eq!(status2, DeletionTaskStatus::Succeeded);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,6 +129,12 @@ pub use iam::service_credentials::{
     ListServiceSpecificCredentialsResponse, ResetServiceSpecificCredentialRequest,
     ResetServiceSpecificCredentialResponse, UpdateServiceSpecificCredentialRequest,
 };
+pub use iam::service_linked_roles::{
+    CreateServiceLinkedRoleRequest, CreateServiceLinkedRoleResponse,
+    DeleteServiceLinkedRoleRequest, DeleteServiceLinkedRoleResponse, DeletionTaskFailureReason,
+    DeletionTaskInfo, DeletionTaskStatus, GetServiceLinkedRoleDeletionStatusRequest,
+    GetServiceLinkedRoleDeletionStatusResponse, RoleUsageType,
+};
 pub use iam::tags::{ListResourceTagsRequest, TagResourceRequest, UntagResourceRequest};
 pub use iam::users::{CreateUserRequest, ListUsersRequest, ListUsersResponse, UpdateUserRequest};
 pub use sso_admin::{CreateAccountAssignmentRequest, CreatePermissionSetRequest};

--- a/src/store/memory.rs
+++ b/src/store/memory.rs
@@ -21,6 +21,8 @@ pub struct InMemoryIamStore {
     server_certificates: HashMap<String, crate::iam::ServerCertificate>, // cert_name -> certificate
     service_specific_credentials:
         HashMap<String, crate::iam::service_credentials::ServiceSpecificCredential>, // cred_id -> credential
+    service_linked_role_deletion_tasks:
+        HashMap<String, crate::iam::service_linked_roles::DeletionTaskInfo>, // task_id -> task info
 }
 
 impl Default for InMemoryIamStore {
@@ -44,6 +46,7 @@ impl InMemoryIamStore {
             credential_report: None,
             server_certificates: HashMap::new(),
             service_specific_credentials: HashMap::new(),
+            service_linked_role_deletion_tasks: HashMap::new(),
         }
     }
 
@@ -61,6 +64,7 @@ impl InMemoryIamStore {
             credential_report: None,
             server_certificates: HashMap::new(),
             service_specific_credentials: HashMap::new(),
+            service_linked_role_deletion_tasks: HashMap::new(),
         }
     }
 }
@@ -644,5 +648,36 @@ impl IamStore for InMemoryIamStore {
         });
 
         Ok(credentials)
+    }
+
+    // Service-linked role deletion task operations
+    async fn create_service_linked_role_deletion_task(
+        &mut self,
+        task: crate::iam::service_linked_roles::DeletionTaskInfo,
+    ) -> Result<crate::iam::service_linked_roles::DeletionTaskInfo> {
+        self.service_linked_role_deletion_tasks
+            .insert(task.deletion_task_id.clone(), task.clone());
+        Ok(task)
+    }
+
+    async fn get_service_linked_role_deletion_task(
+        &self,
+        task_id: &str,
+    ) -> Result<crate::iam::service_linked_roles::DeletionTaskInfo> {
+        self.service_linked_role_deletion_tasks
+            .get(task_id)
+            .cloned()
+            .ok_or_else(|| crate::error::AmiError::ResourceNotFound {
+                resource: format!("Deletion task {} not found", task_id),
+            })
+    }
+
+    async fn update_service_linked_role_deletion_task(
+        &mut self,
+        task: crate::iam::service_linked_roles::DeletionTaskInfo,
+    ) -> Result<crate::iam::service_linked_roles::DeletionTaskInfo> {
+        self.service_linked_role_deletion_tasks
+            .insert(task.deletion_task_id.clone(), task.clone());
+        Ok(task)
     }
 }

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -141,6 +141,20 @@ pub trait IamStore: Send + Sync {
         user_name: Option<&str>,
         service_name: Option<&str>,
     ) -> Result<Vec<crate::iam::service_credentials::ServiceSpecificCredential>>;
+
+    // Service-linked role deletion task operations
+    async fn create_service_linked_role_deletion_task(
+        &mut self,
+        task: crate::iam::service_linked_roles::DeletionTaskInfo,
+    ) -> Result<crate::iam::service_linked_roles::DeletionTaskInfo>;
+    async fn get_service_linked_role_deletion_task(
+        &self,
+        task_id: &str,
+    ) -> Result<crate::iam::service_linked_roles::DeletionTaskInfo>;
+    async fn update_service_linked_role_deletion_task(
+        &mut self,
+        task: crate::iam::service_linked_roles::DeletionTaskInfo,
+    ) -> Result<crate::iam::service_linked_roles::DeletionTaskInfo>;
 }
 
 /// Trait for STS data storage operations


### PR DESCRIPTION
## Overview

This PR implements the service-linked roles module for managing AWS service-linked roles. Service-linked roles are special IAM roles that are directly linked to AWS services and include predefined permissions.

## Changes

### Service-Linked Role Operations
- **create_service_linked_role()** - Creates a service-linked role for an AWS service:
  - Generates role name with `AWSServiceRoleFor` prefix (e.g., `AWSServiceRoleForElasticbeanstalk`)
  - Supports custom suffixes for multiple roles per service (`AWSServiceRoleForLex_MyBot`)
  - Auto-generates trust policy for the service principal
  - Creates role path: `/aws-service-role/service-name/`
  - Generates AROA-prefixed role ID
  - PascalCase conversion for service names
- **delete_service_linked_role()** - Initiates asynchronous deletion:
  - Validates role is actually service-linked (path check)
  - Returns deletion task ID for status tracking
  - Simulates AWS async deletion behavior
- **get_service_linked_role_deletion_status()** - Checks deletion progress:
  - Returns current task status (InProgress, Succeeded, Failed, NotStarted)
  - Completes deletion on status check (simulation)
  - Provides detailed task information

### Deletion Task Tracking
- `DeletionTaskInfo` - Tracks deletion task state:
  - Task ID (UUID)
  - Status (enum)
  - Role name being deleted
  - Failure reason (if applicable)
  - Creation timestamp
- `DeletionTaskStatus` - Task lifecycle states:
  - `InProgress` - Deletion initiated
  - `Succeeded` - Deletion completed
  - `Failed` - Deletion failed
  - `NotStarted` - Task not yet started
- `DeletionTaskFailureReason` - Failure details:
  - Reason description
  - List of resources still using the role
- `RoleUsageType` - Resource usage information:
  - AWS region
  - Resource ARNs

### Storage Layer
- Added deletion task tracking methods to `IamStore` trait:
  - `create_service_linked_role_deletion_task`
  - `get_service_linked_role_deletion_task`
  - `update_service_linked_role_deletion_task`
- Implemented in `InMemoryIamStore` with HashMap storage
- Uses role operations from existing `IamStore` implementation

### Tests
✅ All 123 tests pass including 7 new tests for service-linked roles:
- `test_create_service_linked_role`
- `test_create_service_linked_role_with_custom_suffix`
- `test_create_service_linked_role_with_hyphenated_service`
- `test_delete_service_linked_role`
- `test_delete_non_service_linked_role`
- `test_get_deletion_status`
- `test_deletion_completes_on_status_check`

### Code Quality
✅ No clippy warnings
✅ Code formatted with `cargo fmt`
✅ No linter errors
✅ Comprehensive doctests with examples

## Example Usage

```rust
use rustyiam::{
    MemoryIamClient, CreateServiceLinkedRoleRequest,
    DeleteServiceLinkedRoleRequest, 
    GetServiceLinkedRoleDeletionStatusRequest
};

let store = rustyiam::create_memory_store();
let mut client = MemoryIamClient::new(store);

// Create a service-linked role
let request = CreateServiceLinkedRoleRequest {
    aws_service_name: "elasticbeanstalk.amazonaws.com".to_string(),
    description: Some("Service role for Elastic Beanstalk".to_string()),
    custom_suffix: None,
};

let response = client.create_service_linked_role(request).await?;
let role = response.data.unwrap().role;
println!("Created: {} at {}", role.role_name, role.path);
// Output: Created: AWSServiceRoleForElasticbeanstalk at /aws-service-role/elasticbeanstalk.amazonaws.com/

// Delete the role
let delete_req = DeleteServiceLinkedRoleRequest {
    role_name: role.role_name.clone(),
};
let delete_resp = client.delete_service_linked_role(delete_req).await?;
let task_id = delete_resp.data.unwrap().deletion_task_id;

// Check deletion status
let status_req = GetServiceLinkedRoleDeletionStatusRequest {
    deletion_task_id: task_id,
};
let status_resp = client.get_service_linked_role_deletion_status(status_req).await?;
println!("Status: {:?}", status_resp.data.unwrap().status);
// Output: Status: Succeeded
```

## AWS Service-Linked Roles

Service-linked roles are used by AWS services to perform actions on your behalf:
- **Elastic Beanstalk** - `elasticbeanstalk.amazonaws.com`
- **Amazon Lex** - `lex.amazonaws.com`
- **ElastiCache** - `elasticache.amazonaws.com`
- **Auto Scaling** - `autoscaling.amazonaws.com`
- And many more...

## Key Features

1. **Automatic Naming** - Converts service names to PascalCase and prefixes with `AWSServiceRoleFor`
2. **Custom Suffixes** - Support for multiple service-linked roles per service
3. **Path Isolation** - Service-linked roles use `/aws-service-role/` paths
4. **Trust Policy Generation** - Auto-creates trust policies for service principals
5. **Async Deletion** - Mimics AWS behavior with task tracking
6. **Validation** - Ensures only service-linked roles can be deleted via this API
7. **Status Tracking** - Complete lifecycle management with detailed task info

## Related Issues

Completes the service-linked roles module implementation.