### PR TITLE
refactor: Move tenant store to centralized store module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -101,7 +101,7 @@ pub use sso_admin::{
 };
 
 // Re-export Tenant types
-pub use tenant::store::TenantAction;
+pub use store::TenantAction;
 pub use tenant::{
     BillingInfo, QuotaMode, Tenant, TenantId, TenantQuotas, TenantStatus, TenantType, TenantUsage,
 };

--- a/src/store/memory/mod.rs
+++ b/src/store/memory/mod.rs
@@ -6,9 +6,11 @@
 mod iam;
 mod sso_admin;
 mod sts;
+mod tenant;
 mod unified;
 
 pub use iam::InMemoryIamStore;
 pub use sso_admin::InMemorySsoAdminStore;
 pub use sts::InMemoryStsStore;
+pub use tenant::InMemoryTenantStore;
 pub use unified::InMemoryStore;

--- a/src/store/memory/tenant.rs
+++ b/src/store/memory/tenant.rs
@@ -1,7 +1,7 @@
 //! In-Memory Tenant Store Implementation
 
-use super::{TenantAction, TenantStore};
 use crate::error::{AmiError, Result};
+use crate::store::traits::{TenantAction, TenantStore};
 use crate::tenant::{Tenant, TenantId, TenantQuotas, TenantUsage};
 use async_trait::async_trait;
 use std::collections::HashMap;

--- a/src/store/memory/unified.rs
+++ b/src/store/memory/unified.rs
@@ -4,9 +4,10 @@
 
 use crate::error::Result;
 use crate::provider::{AwsProvider, CloudProvider};
-use crate::store::memory::{InMemoryIamStore, InMemorySsoAdminStore, InMemoryStsStore};
+use crate::store::memory::{
+    InMemoryIamStore, InMemorySsoAdminStore, InMemoryStsStore, InMemoryTenantStore,
+};
 use crate::store::Store;
-use crate::tenant::store::InMemoryTenantStore;
 use async_trait::async_trait;
 use std::sync::Arc;
 

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -8,12 +8,11 @@ pub mod memory;
 pub mod traits;
 
 // Re-export traits for convenience
-pub use traits::{IamStore, SsoAdminStore, StsStore};
+pub use traits::{IamStore, SsoAdminStore, StsStore, TenantAction, TenantStore};
 
 // Re-export the Store trait
 use crate::error::Result;
 use crate::provider::CloudProvider;
-use crate::tenant::store::TenantStore;
 use async_trait::async_trait;
 
 /// Generic store trait that can be implemented by any backend

--- a/src/store/traits/mod.rs
+++ b/src/store/traits/mod.rs
@@ -6,7 +6,9 @@
 mod iam;
 mod sso_admin;
 mod sts;
+mod tenant;
 
 pub use iam::IamStore;
 pub use sso_admin::SsoAdminStore;
 pub use sts::StsStore;
+pub use tenant::{TenantAction, TenantStore};

--- a/src/store/traits/tenant.rs
+++ b/src/store/traits/tenant.rs
@@ -1,11 +1,7 @@
-//! Tenant Store Trait and Implementations
+//! Tenant Store Trait
 
-pub mod memory;
-
-pub use memory::InMemoryTenantStore;
-
-use super::{Tenant, TenantId, TenantQuotas, TenantUsage};
 use crate::error::Result;
+use crate::tenant::{Tenant, TenantId, TenantQuotas, TenantUsage};
 use async_trait::async_trait;
 
 /// Tenant actions for permission checking

--- a/src/tenant/client.rs
+++ b/src/tenant/client.rs
@@ -1,10 +1,8 @@
 //! Tenant Client for Managing Tenants
 
-use super::{
-    store::{TenantAction, TenantStore},
-    BillingInfo, QuotaMode, Tenant, TenantId, TenantQuotas, TenantStatus, TenantType,
-};
+use super::{BillingInfo, QuotaMode, Tenant, TenantId, TenantQuotas, TenantStatus, TenantType};
 use crate::error::{AmiError, Result};
+use crate::store::traits::{TenantAction, TenantStore};
 use crate::store::Store;
 use crate::types::AmiResponse;
 use std::collections::HashMap;

--- a/src/tenant/mod.rs
+++ b/src/tenant/mod.rs
@@ -24,11 +24,9 @@
 pub mod client;
 pub mod hierarchy;
 pub mod model;
-pub mod store;
 
 #[cfg(test)]
 mod tests;
 
 pub use client::TenantClient;
 pub use model::*;
-pub use store::{InMemoryTenantStore, TenantStore};


### PR DESCRIPTION
## 🎯 What's Changed

This PR refactors the tenant module's store structure to be consistent with IAM, STS, and SSO Admin modules.

## 📁 Changes

### Before (Inconsistent)
```
src/tenant/
  - store/              ❌ Store shouldn't be here
    - mod.rs           ❌ Trait in wrong location
    - memory.rs        ❌ Implementation in wrong location
```

### After (Consistent)
```
src/tenant/
  - mod.rs             ✅ Module declaration
  - model.rs           ✅ Models
  - client.rs          ✅ Business logic
  - hierarchy.rs       ✅ Utilities
  - tests.rs           ✅ Tests

src/store/traits/
  - tenant.rs          ✅ TenantStore trait

src/store/memory/
  - tenant.rs          ✅ InMemoryTenantStore
```

## 🔧 Technical Details

- Moved `TenantStore` trait from `src/tenant/store/mod.rs` → `src/store/traits/tenant.rs`
- Moved `InMemoryTenantStore` from `src/tenant/store/memory.rs` → `src/store/memory/tenant.rs`
- Updated all imports across the codebase
- Removed `src/tenant/store/` directory entirely

## ✅ Testing

- All 155 tests pass
- Pre-commit checks pass (formatting, clippy)

## 🎨 Why This Matters

This makes the codebase more consistent and maintainable by following the same pattern across all modules:
- **Domain logic** lives in `src/{module}/` (models, client, operations)
- **Store traits** live in `src/store/traits/` (persistence interface)
- **Store implementations** live in `src/store/memory/` (in-memory backend)

## 📚 Related

Part of the ongoing effort to maintain consistent architecture across the WAMI codebase.