### PR TITLE
refactor(context): derive tenant, instance and root from the caller ARN

### DIFF
--- a/crates/wami-core/src/arn/mod.rs
+++ b/crates/wami-core/src/arn/mod.rs
@@ -102,4 +102,6 @@ pub use transformer::{
     get_transformer, ArnTransformer, AwsArnTransformer, AzureArnTransformer, GcpArnTransformer,
     ProviderArnInfo, ScalewayArnTransformer,
 };
-pub use types::{CloudMapping, Resource, Service, TenantPath, WamiArn};
+pub use types::{
+    CloudMapping, Resource, Service, TenantPath, WamiArn, ROOT_TENANT_ID, ROOT_USER_NAME,
+};

--- a/crates/wami-core/src/arn/types.rs
+++ b/crates/wami-core/src/arn/types.rs
@@ -4,6 +4,12 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use std::fmt;
 use std::str::FromStr;
 
+/// Name of the platform root user.
+pub const ROOT_USER_NAME: &str = "root";
+
+/// Tenant the platform root user belongs to.
+pub const ROOT_TENANT_ID: u64 = 0;
+
 /// Represents a WAMI ARN (Amazon Resource Name).
 ///
 /// # Format
@@ -348,6 +354,22 @@ impl WamiArn {
     /// Returns true if this resource is synced with a cloud provider.
     pub fn is_cloud_synced(&self) -> bool {
         self.cloud_mapping.is_some()
+    }
+
+    /// Returns true if this ARN identifies the platform root user.
+    ///
+    /// Both conditions must hold: the resource is the user named
+    /// [`ROOT_USER_NAME`], **and** it sits in the root tenant
+    /// ([`ROOT_TENANT_ID`]).
+    ///
+    /// The tenant check is not redundant. A root context bypasses every
+    /// authorization check, so deriving it from a name alone would make the
+    /// privilege reachable by anything able to influence a resource id — and
+    /// nothing forbids naming a user `root` inside an ordinary tenant.
+    pub fn is_root_user(&self) -> bool {
+        self.resource.resource_type == "user"
+            && self.resource.resource_id == ROOT_USER_NAME
+            && self.tenant_path.root_u64() == Some(ROOT_TENANT_ID)
     }
 
     /// Returns the cloud provider name if synced.

--- a/crates/wami-core/src/context.rs
+++ b/crates/wami-core/src/context.rs
@@ -21,10 +21,9 @@
 //! use wami_core::arn::{TenantPath, WamiArn};
 //! use wami_core::context::WamiContext;
 //!
-//! // Build a context for testing/internal use
+//! // The caller ARN is the only required field: the tenant path, the instance
+//! // and whether the caller is root are all read from it.
 //! let context = WamiContext::builder()
-//!     .instance_id("123456789012")
-//!     .tenant_path(TenantPath::single(0))
 //!     .caller_arn(
 //!         WamiArn::builder()
 //!             .service(wami_core::arn::Service::Iam)
@@ -34,12 +33,18 @@
 //!             .build()
 //!             .unwrap(),
 //!     )
-//!     .is_root(false)
 //!     .build()
 //!     .unwrap();
 //!
 //! assert_eq!(context.instance_id(), "123456789012");
+//! assert_eq!(context.tenant_path(), &TenantPath::single(0));
+//! assert!(!context.is_root());
 //! ```
+//!
+//! `tenant_path` and `instance_id` can still be set explicitly, but only to
+//! widen an operation beyond the caller's own scope — cross-tenant work or
+//! impersonation. Restating them to repeat what the ARN already says is what
+//! allowed the two to drift apart.
 
 use crate::arn::{TenantPath, WamiArn};
 use crate::error::{AmiError, Result};
@@ -178,7 +183,8 @@ pub struct WamiContextBuilder {
     tenant_path: Option<TenantPath>,
     instance_id: Option<String>,
     caller_arn: Option<WamiArn>,
-    is_root: bool,
+    /// `None` means "derive from the caller ARN"; an explicit value always wins.
+    is_root: Option<bool>,
     region: Option<String>,
     session_info: Option<SessionInfo>,
     source_ip: Option<String>,
@@ -206,8 +212,12 @@ impl WamiContextBuilder {
     }
 
     /// Set whether the caller is a root user
+    ///
+    /// Leave it unset to derive it from the caller ARN. An explicit value is
+    /// never overridden — in particular `is_root(false)` stays false even for
+    /// a root ARN, which is what makes deliberate privilege dropping possible.
     pub fn is_root(mut self, is_root: bool) -> Self {
-        self.is_root = is_root;
+        self.is_root = Some(is_root);
         self
     }
 
@@ -244,17 +254,21 @@ impl WamiContextBuilder {
     /// Build the WamiContext
     #[allow(clippy::result_large_err)]
     pub fn build(self) -> Result<WamiContext> {
-        let tenant_path = self.tenant_path.ok_or_else(|| AmiError::InvalidParameter {
-            message: "tenant_path is required".to_string(),
-        })?;
-
-        let instance_id = self.instance_id.ok_or_else(|| AmiError::InvalidParameter {
-            message: "instance_id is required".to_string(),
-        })?;
-
+        // The ARN comes first because the other three fields are derived from
+        // it. Stating them again is allowed, but only to widen the scope of an
+        // operation (cross-tenant, impersonation); leaving them out is the
+        // normal case and cannot drift from the caller's identity.
         let caller_arn = self.caller_arn.ok_or_else(|| AmiError::InvalidParameter {
             message: "caller_arn is required".to_string(),
         })?;
+
+        let tenant_path = self
+            .tenant_path
+            .unwrap_or_else(|| caller_arn.tenant_path.clone());
+
+        let instance_id = self
+            .instance_id
+            .unwrap_or_else(|| caller_arn.wami_instance_id.clone());
 
         // Validate that instance_id is not empty
         if instance_id.trim().is_empty() {
@@ -266,8 +280,8 @@ impl WamiContextBuilder {
         Ok(WamiContext {
             tenant_path,
             instance_id,
+            is_root: self.is_root.unwrap_or_else(|| caller_arn.is_root_user()),
             caller_arn,
-            is_root: self.is_root,
             region: self.region,
             session_info: self.session_info,
             source_ip: self.source_ip,
@@ -462,15 +476,95 @@ mod tests {
     }
 
     #[test]
-    fn test_missing_required_fields() {
-        // Missing instance_id
+    fn test_caller_arn_is_the_only_required_field() {
+        // tenant_path and instance_id are derived, so neither is enough alone.
         let result = WamiContext::builder()
             .tenant_path(TenantPath::single(0))
             .build();
         assert!(result.is_err());
 
-        // Missing tenant_path
         let result = WamiContext::builder().instance_id("999888777").build();
         assert!(result.is_err());
+    }
+
+    /// Helper: an ARN for `user_id` inside `tenant`.
+    fn arn_for(tenant: u64, user_id: &str) -> WamiArn {
+        WamiArn::builder()
+            .service(crate::arn::Service::Iam)
+            .tenant_path(TenantPath::single(tenant))
+            .wami_instance("999888777")
+            .resource("user", user_id)
+            .build()
+            .unwrap()
+    }
+
+    #[test]
+    fn test_scope_is_derived_from_caller_arn() {
+        let context = WamiContext::builder()
+            .caller_arn(arn_for(12345678, "alice"))
+            .build()
+            .unwrap();
+
+        assert_eq!(context.tenant_path(), &TenantPath::single(12345678));
+        assert_eq!(context.instance_id(), "999888777");
+    }
+
+    #[test]
+    fn test_explicit_scope_still_wins() {
+        // Cross-tenant operations are the reason the overrides remain.
+        let context = WamiContext::builder()
+            .caller_arn(arn_for(12345678, "alice"))
+            .tenant_path(TenantPath::single(87654321))
+            .instance_id("111222333")
+            .build()
+            .unwrap();
+
+        assert_eq!(context.tenant_path(), &TenantPath::single(87654321));
+        assert_eq!(context.instance_id(), "111222333");
+    }
+
+    #[test]
+    fn test_root_is_derived_from_root_arn() {
+        let context = WamiContext::builder()
+            .caller_arn(arn_for(0, "root"))
+            .build()
+            .unwrap();
+
+        assert!(context.is_root());
+    }
+
+    #[test]
+    fn test_a_user_named_root_in_another_tenant_is_not_root() {
+        // The whole reason is_root_user checks the tenant as well as the name:
+        // is_root bypasses every authorization check, so it must not be
+        // reachable by naming a resource `root` in a tenant one controls.
+        let context = WamiContext::builder()
+            .caller_arn(arn_for(12345678, "root"))
+            .build()
+            .unwrap();
+
+        assert!(!context.is_root());
+    }
+
+    #[test]
+    fn test_ordinary_user_in_root_tenant_is_not_root() {
+        let context = WamiContext::builder()
+            .caller_arn(arn_for(0, "alice"))
+            .build()
+            .unwrap();
+
+        assert!(!context.is_root());
+    }
+
+    #[test]
+    fn test_explicit_is_root_false_beats_a_root_arn() {
+        // Dropping privileges deliberately has to remain possible.
+        let context = WamiContext::builder()
+            .caller_arn(arn_for(0, "root"))
+            .is_root(false)
+            .build()
+            .unwrap();
+
+        assert!(!context.is_root());
     }
 }

--- a/crates/wami/src/service/auth/authentication.rs
+++ b/crates/wami/src/service/auth/authentication.rs
@@ -166,22 +166,10 @@ where
     async fn create_context_from_user(&self, user: &User) -> Result<WamiContext> {
         let arn = &user.wami_arn;
 
-        // Check if this is the root user
-        // Root user is in the root tenant (ID = 0)
-        let is_root = user.user_name == ROOT_USER_NAME
-            && arn.tenant_path.root_u64() == Some(crate::wami::identity::root_user::ROOT_TENANT_ID);
-
-        // Extract instance_id and tenant_path from the ARN
-        let instance_id = arn.wami_instance_id.clone();
-        let tenant_path = arn.tenant_path.clone();
-
-        // Create the context
-        WamiContext::builder()
-            .instance_id(instance_id)
-            .tenant_path(tenant_path)
-            .caller_arn(arn.clone())
-            .is_root(is_root)
-            .build()
+        // tenant_path, instance_id and is_root all come from the ARN now — see
+        // WamiContextBuilder::build. Restating them here was how they could
+        // disagree with the identity they are supposed to describe.
+        WamiContext::builder().caller_arn(arn.clone()).build()
     }
 
     /// Create context for a root user

--- a/crates/wami/src/wami/identity/root_user.rs
+++ b/crates/wami/src/wami/identity/root_user.rs
@@ -43,11 +43,11 @@ use crate::wami::identity::User;
 use chrono::Utc;
 use serde::{Deserialize, Serialize};
 
-/// Constants for root user
-pub const ROOT_USER_NAME: &str = "root";
-/// Root tenant numeric ID constant
-/// Using 0 as a special reserved value for root tenant
-pub const ROOT_TENANT_ID: u64 = 0;
+// Re-exported rather than redefined: `WamiArn::is_root_user` decides the same
+// question inside wami-core, and two copies of these values could drift into a
+// state where a context is root by one definition and not by the other.
+pub use wami_core::arn::{ROOT_TENANT_ID, ROOT_USER_NAME};
+
 pub const ROOT_USER_ID: &str = "root";
 
 /// Root User - Special administrative user with full access


### PR DESCRIPTION
Closes #67.

## The redundancy

`WamiContextBuilder` required `tenant_path` and `instance_id` next to `caller_arn`, although the ARN carries both. Two sources for one truth can disagree, and a context whose `tenant_path` differs from its caller's authorizes against the wrong scope.

`caller_arn` is now the only required field:

```rust
let context = WamiContext::builder()
    .caller_arn(caller_arn)
    .build()?;              // tenant_path, instance_id and is_root all follow
```

Both overrides remain, for the one case where restating them says something: widening an operation past the caller's own scope — cross-tenant work, impersonation.

## Two departures from the issue

**`instance_id` derives from `wami_instance_id`, not `provider_account()`.** The issue proposes the latter, but that field lives in the optional `cloud_mapping` and is absent from any deployment that syncs with no cloud. Following it literally would break the native case.

**`is_root` is not derived from the resource type alone.** The issue suggests `resource_type == "root"`; it is the resource *id* that holds `root`, and more importantly a root context bypasses **every** authorization check. Deriving it from a name would put that privilege within reach of anyone able to influence a resource id — and nothing reserves the name `root` inside an ordinary tenant.

`WamiArn::is_root_user()` therefore requires both conditions:

```rust
self.resource.resource_type == "user"
    && self.resource.resource_id == ROOT_USER_NAME
    && self.tenant_path.root_u64() == Some(ROOT_TENANT_ID)
```

This is the rule `AuthenticationService::create_context_from_user` already applied inline. `is_root` becomes `Option<bool>` so that an explicit `is_root(false)` still wins over a root ARN — deliberately dropping privileges has to stay possible.

## Also

- `create_context_from_user` recomputed all three fields by hand; it now passes the ARN and nothing else.
- `ROOT_USER_NAME` and `ROOT_TENANT_ID` move to `wami-core` and are re-exported from their old path. Two copies could drift into a state where a context is root by one definition and not the other.

## Verification

`1411 passed; 0 failed` across the workspace, clippy clean. Six new tests cover the derivation, the cross-tenant override, and the three cases that must **not** grant root: a user named `root` in another tenant, an ordinary user in the root tenant, and an explicit `is_root(false)` over a root ARN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)