### PR TITLE
refactor!: no cloud provider knowledge in a default build

### DIFF
--- a/crates/wami-core/Cargo.toml
+++ b/crates/wami-core/Cargo.toml
@@ -6,15 +6,17 @@ license = "MIT"
 description = "Core primitives shared across the WAMI workspace"
 
 [dependencies]
-# Only their generated `Error` types are used, in error.rs. Their default
-# features pull a full HTTP stack — hyper, rustls, and through it aws-lc-sys,
-# which builds C via cmake and does not compile under current MSVC. Three enum
-# variants are not worth a C toolchain on every platform that consumes this.
-aws-sdk-iam = { version = "1.0", default-features = false }
-aws-sdk-sts = { version = "1.0", default-features = false }
-aws-sdk-ssoadmin = { version = "1.91", default-features = false }
 chrono = { version = "0.4", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "2.0"
 
+[features]
+# No provider by default. A deployment that is its own identity provider —
+# no AWS, no GCP — should not compile translations for clouds it never calls.
+default = []
+aws = []
+gcp = []
+azure = []
+scaleway = []
+all-providers = ["aws", "gcp", "azure", "scaleway"]

--- a/crates/wami-core/README.md
+++ b/crates/wami-core/README.md
@@ -59,3 +59,4 @@ let context = WamiContext::builder()
 Licensed under MIT. See [`../LICENSE`](../../LICENSE) for details.
 
 
+

--- a/crates/wami-core/src/arn/mod.rs
+++ b/crates/wami-core/src/arn/mod.rs
@@ -71,7 +71,10 @@
 //!
 //! ## Transforming to Provider Formats
 //!
+//! Requires the `aws` feature; provider translations are off by default.
+//!
 //! ```
+//! # #[cfg(feature = "aws")] {
 //! use wami_core::arn::{WamiArn, Service, AwsArnTransformer, ArnTransformer};
 //!
 //! let arn = WamiArn::builder()
@@ -86,6 +89,7 @@
 //! let transformer = AwsArnTransformer;
 //! let aws_arn = transformer.to_provider_arn(&arn).unwrap();
 //! assert_eq!(aws_arn, "arn:aws:iam::223344556677:user/77557755");
+//! # }
 //! ```
 
 pub mod builder;
@@ -98,10 +102,17 @@ pub mod types;
 pub use builder::ArnBuilder;
 pub use matching::{glob_match, matches_arn_pattern, MatchContext};
 pub use parser::{parse_arn, ArnParseError};
-pub use transformer::{
-    get_transformer, ArnTransformer, AwsArnTransformer, AzureArnTransformer, GcpArnTransformer,
-    ProviderArnInfo, ScalewayArnTransformer,
-};
+pub use transformer::{available_providers, get_transformer, ArnTransformer, ProviderArnInfo};
+// Each translation is behind its provider's feature, off by default: a
+// deployment that syncs with no cloud should not compile any of them.
+#[cfg(feature = "aws")]
+pub use transformer::AwsArnTransformer;
+#[cfg(feature = "azure")]
+pub use transformer::AzureArnTransformer;
+#[cfg(feature = "gcp")]
+pub use transformer::GcpArnTransformer;
+#[cfg(feature = "scaleway")]
+pub use transformer::ScalewayArnTransformer;
 pub use types::{
     CloudMapping, Resource, Service, TenantPath, WamiArn, ROOT_TENANT_ID, ROOT_USER_NAME,
 };

--- a/crates/wami-core/src/arn/transformer/mod.rs
+++ b/crates/wami-core/src/arn/transformer/mod.rs
@@ -4,14 +4,22 @@
 //! lives in its own file. Adding one is adding a file, not editing a
 //! seven-hundred-line module shared with three others.
 
+#[cfg(feature = "aws")]
 mod aws;
+#[cfg(feature = "azure")]
 mod azure;
+#[cfg(feature = "gcp")]
 mod gcp;
+#[cfg(feature = "scaleway")]
 mod scaleway;
 
+#[cfg(feature = "aws")]
 pub use aws::AwsArnTransformer;
+#[cfg(feature = "azure")]
 pub use azure::AzureArnTransformer;
+#[cfg(feature = "gcp")]
 pub use gcp::GcpArnTransformer;
+#[cfg(feature = "scaleway")]
 pub use scaleway::ScalewayArnTransformer;
 
 use crate::arn::types::WamiArn;
@@ -55,25 +63,63 @@ pub struct ProviderArnInfo {
 
 /// Gets the appropriate transformer for a given provider.
 ///
+/// Returns `None` for a provider whose feature is not enabled, which by
+/// default is all of them. Ask [`available_providers`] what this build can
+/// actually translate for.
+///
 /// # Examples
 ///
 /// ```
+/// use wami_core::arn::{available_providers, get_transformer};
+///
+/// // Holds for any set of enabled features, including none.
+/// for provider in available_providers() {
+///     assert!(get_transformer(provider).is_some());
+/// }
+///
+/// assert!(get_transformer("unknown").is_none());
+/// ```
+///
+/// With the `aws` feature enabled:
+///
+/// ```
+/// # #[cfg(feature = "aws")] {
 /// use wami_core::arn::get_transformer;
-///
-/// let transformer = get_transformer("aws");
-/// assert!(transformer.is_some());
-///
-/// let transformer = get_transformer("unknown");
-/// assert!(transformer.is_none());
+/// assert!(get_transformer("aws").is_some());
+/// # }
 /// ```
 pub fn get_transformer(provider: &str) -> Option<Box<dyn ArnTransformer>> {
     match provider {
+        #[cfg(feature = "aws")]
         "aws" => Some(Box::new(AwsArnTransformer)),
+        #[cfg(feature = "gcp")]
         "gcp" => Some(Box::new(GcpArnTransformer)),
+        #[cfg(feature = "azure")]
         "azure" => Some(Box::new(AzureArnTransformer)),
+        #[cfg(feature = "scaleway")]
         "scaleway" => Some(Box::new(ScalewayArnTransformer)),
         _ => None,
     }
+}
+
+/// The providers this build can translate for.
+///
+/// With no provider feature enabled — the default — this is empty and
+/// [`get_transformer`] returns `None` for everything. That is correct for a
+/// deployment that syncs with no cloud, and indistinguishable from a typo
+/// without somewhere to ask. This is that place, so the answer does not
+/// require reading a Cargo.toml.
+pub fn available_providers() -> &'static [&'static str] {
+    &[
+        #[cfg(feature = "aws")]
+        "aws",
+        #[cfg(feature = "gcp")]
+        "gcp",
+        #[cfg(feature = "azure")]
+        "azure",
+        #[cfg(feature = "scaleway")]
+        "scaleway",
+    ]
 }
 
 #[cfg(test)]
@@ -81,11 +127,35 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_transformer() {
-        assert!(get_transformer("aws").is_some());
-        assert!(get_transformer("gcp").is_some());
-        assert!(get_transformer("azure").is_some());
-        assert!(get_transformer("scaleway").is_some());
+    fn the_inventory_and_the_registry_agree() {
+        // Stated as a property rather than a list of providers, so it holds
+        // whatever set of features a build enables — including none, which is
+        // the default and the case that matters to a consumer with no cloud.
+        for provider in available_providers() {
+            assert!(
+                get_transformer(provider).is_some(),
+                "{provider} is advertised but cannot be built"
+            );
+        }
         assert!(get_transformer("unknown").is_none());
+    }
+
+    #[test]
+    fn no_provider_is_available_unless_asked_for() {
+        // The reason the inventory exists: without it, an empty result is
+        // indistinguishable from a typo, and nothing says which it was.
+        #[cfg(not(any(
+            feature = "aws",
+            feature = "gcp",
+            feature = "azure",
+            feature = "scaleway"
+        )))]
+        {
+            assert!(available_providers().is_empty());
+            assert!(get_transformer("aws").is_none());
+        }
+
+        #[cfg(feature = "aws")]
+        assert!(available_providers().contains(&"aws"));
     }
 }

--- a/crates/wami-core/src/error.rs
+++ b/crates/wami-core/src/error.rs
@@ -2,14 +2,27 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum AmiError {
-    #[error("AWS SDK error: {0}")]
-    AwsSdk(#[from] aws_sdk_iam::Error),
-
-    #[error("STS SDK error: {0}")]
-    StsSdk(#[from] aws_sdk_sts::Error),
-
-    #[error("SSO Admin SDK error: {0}")]
-    SsoAdminSdk(#[from] aws_sdk_ssoadmin::Error),
+    /// A provider rejected an operation.
+    ///
+    /// Replaces the AwsSdk, StsSdk and SsoAdminSdk variants removed in 0.14.
+    /// Those named SDK error types in their signature, so every consumer
+    /// compiled three AWS SDKs to hold three variants this workspace never
+    /// constructed once. Carrying the provider name and its message keeps the
+    /// information without keeping the dependency:
+    ///
+    /// ```ignore
+    /// client.get_user().send().await.map_err(|e| AmiError::Provider {
+    ///     provider: "aws".to_string(),
+    ///     message: e.to_string(),
+    /// })?
+    /// ```
+    #[error("{provider} error: {message}")]
+    Provider {
+        /// Which provider refused.
+        provider: String,
+        /// What it said.
+        message: String,
+    },
 
     #[error("Serialization error: {0}")]
     Serialization(#[from] serde_json::Error),

--- a/crates/wami-credentials/README.md
+++ b/crates/wami-credentials/README.md
@@ -56,3 +56,4 @@ assert!(access_key.wami_arn.to_string().contains("access-key"));
 Licensed under MIT. See [`../LICENSE`](../../LICENSE) for details.
 
 
+

--- a/crates/wami-identity/README.md
+++ b/crates/wami-identity/README.md
@@ -56,3 +56,4 @@ assert!(user.wami_arn.to_string().contains("user/alice"));
 Licensed under MIT. See [`../LICENSE`](../../LICENSE) for details.
 
 
+

--- a/crates/wami-macros/README.md
+++ b/crates/wami-macros/README.md
@@ -52,3 +52,4 @@ cargo test -p wami-macros
 Licensed under MIT. See [`../LICENSE`](../../LICENSE) for details.
 
 
+

--- a/crates/wami-service/README.md
+++ b/crates/wami-service/README.md
@@ -49,3 +49,4 @@ assert_eq!(service.handle("hello".into()).unwrap(), "hello");
 Licensed under MIT. See [`../LICENSE`](../../LICENSE) for details.
 
 
+

--- a/crates/wami-traits/README.md
+++ b/crates/wami-traits/README.md
@@ -62,3 +62,4 @@ fn register_service(registry: &mut dyn ServiceRegistry) {
 Licensed under MIT. See [`../LICENSE`](../../LICENSE) for details.
 
 
+

--- a/crates/wami/Cargo.toml
+++ b/crates/wami/Cargo.toml
@@ -14,10 +14,6 @@ keywords = ["iam", "sso", "identity", "multicloud", "aws"]
 categories = ["api-bindings", "authentication", "development-tools"]
 
 [dependencies]
-# See wami-core: re-exported types only, no client is ever constructed.
-aws-sdk-iam = { version = "1.0", default-features = false }
-aws-sdk-sts = { version = "1.0", default-features = false }
-aws-sdk-ssoadmin = { version = "1.91", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.0", features = ["full"] }
@@ -50,5 +46,19 @@ wami-core = { path = "../wami-core" }
 wami-macros = { path = "../wami-macros" }
 
 [features]
+# Provider translations, forwarded to wami-core. Off by default there, so off
+# here unless asked for.
+aws = ["wami-core/aws"]
+gcp = ["wami-core/gcp"]
+azure = ["wami-core/azure"]
+scaleway = ["wami-core/scaleway"]
+all-providers = ["wami-core/all-providers"]
 default = ["sts-jwt"]
 sts-jwt = ["dep:ed25519-dalek", "dep:jsonwebtoken"]
+
+# Demonstrates every provider translation, so it only builds when they exist.
+# Without this, `cargo check --all-targets` on a default build fails on an
+# example rather than on anything a consumer would ship.
+[[example]]
+name = "25_arn_usage"
+required-features = ["all-providers"]

--- a/crates/wami/README.md
+++ b/crates/wami/README.md
@@ -29,3 +29,4 @@ cargo test
 Licensed under MIT. See [`../../LICENSE`](../../LICENSE) for details.
 
 
+

--- a/crates/wami/src/lib.rs
+++ b/crates/wami/src/lib.rs
@@ -87,10 +87,18 @@ pub use wami_core::types::{
 
 // Re-export ARN types
 pub use wami_core::arn::{
-    get_transformer, parse_arn, ArnBuilder, ArnParseError, ArnTransformer, AwsArnTransformer,
-    AzureArnTransformer, CloudMapping, GcpArnTransformer, ProviderArnInfo, Resource,
-    ScalewayArnTransformer, Service, TenantPath, WamiArn,
+    available_providers, get_transformer, parse_arn, ArnBuilder, ArnParseError, ArnTransformer,
+    CloudMapping, ProviderArnInfo, Resource, Service, TenantPath, WamiArn,
 };
+// Behind their provider's feature, all off by default.
+#[cfg(feature = "aws")]
+pub use wami_core::arn::AwsArnTransformer;
+#[cfg(feature = "azure")]
+pub use wami_core::arn::AzureArnTransformer;
+#[cfg(feature = "gcp")]
+pub use wami_core::arn::GcpArnTransformer;
+#[cfg(feature = "scaleway")]
+pub use wami_core::arn::ScalewayArnTransformer;
 
 // Re-export context types
 pub use wami_core::context::{SessionInfo, WamiContext};


### PR DESCRIPTION
**BREAKING CHANGE** — `AmiError` loses three variants, provider translations move behind features. Releases as 0.14.0.

Answers the point recorded in #103 and again in #66: a consumer that is its own identity provider, syncing with no cloud, still compiled knowledge of four clouds it will never call.

## The dead variants were the expensive part

`AmiError` declared `AwsSdk`, `StsSdk` and `SsoAdminSdk`, each naming an SDK error type via `#[from]`. **None is constructed anywhere in the workspace** — no `?` on an SDK call, no client ever built. Declaring them pulled six dependencies and three AWS SDKs into every consumer.

They are removed, and replaced by one variant that carries the same information without the dependency:

```rust
AmiError::Provider { provider: String, message: String }
```

Anyone who was converting through `?` has a path:

```rust
.map_err(|e| AmiError::Provider { provider: "aws".to_string(), message: e.to_string() })
```

### On deprecating instead

Suggested in review, and declined deliberately: a deprecated variant keeps its `#[from]` on the SDK type, and therefore keeps the dependency. Removing the dependency *is* the gain here, so deprecation would have deferred all of it — in exchange for warning about variants nobody can construct.

## The transformers

The trait was never what was missing. `ArnTransformer` exists and all four implementations satisfy it. What kept them in the core is `get_transformer` matching on hardcoded names: a match arm needs its type in scope.

They now sit behind per-provider features, `default = []`.

**This does not remove the coupling, and the commit says so.** Each provider still needs a `#[cfg]` arm in the same match, so adding one still edits wami. What it removes is the *cost*, which is what a consumer actually feels. A registry providers register into would remove the coupling as well — worth doing the day someone outside wants to plug their own in, on a core already this light.

`available_providers()` ships with it. With nothing enabled every lookup returns `None`, and an empty result is otherwise indistinguishable from a typo with nowhere to ask. Its test is a property — everything advertised can be built — so it holds for any feature set, including none.

Example 25 gains `required-features`, since it demonstrates all four.

## Verification, in both shapes

| | tests | clippy |
|---|---|---|
| default (no provider) | 1427 | clean |
| `all-providers` | 1442 | clean |

`aws-sdk-iam`, `aws-sdk-sts`, `aws-sdk-ssoadmin`, `aws-config` and `aws-smithy-runtime` are **absent from the dependency tree** of a default build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)