### PR TITLE
refactor!: settle every store lock on tokio::sync::RwLock

### DIFF
--- a/crates/wami-macros/README.md
+++ b/crates/wami-macros/README.md
@@ -20,7 +20,8 @@ wami-macros = { path = "../wami-macros" }
 ```
 
 ```rust
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_macros::service;
 use wami_traits::Service;
 
@@ -34,10 +35,15 @@ pub struct UserService<S> {
 
 impl<S: UserServiceStore> UserService<S> {
     pub async fn get_user(&self, user_name: &str) -> wami::Result<Option<wami::identity::User>> {
-        self.read_store().get_user(user_name).await
+        self.read_store().await.get_user(user_name).await
     }
 }
 ```
+
+The lock is `tokio::sync::RwLock`, not `std::sync::RwLock`: the store traits are
+async, so a service holding a blocking guard across an `.await` would stall a
+runtime thread and make its futures non-`Send`. `read_store()` and
+`write_store()` are therefore async, and there is no lock poisoning to handle.
 
 ## Development
 

--- a/crates/wami-macros/src/service_attr.rs
+++ b/crates/wami-macros/src/service_attr.rs
@@ -89,11 +89,11 @@ fn expand_inner(args: ServiceArgs, item_struct: ItemStruct) -> Result<proc_macro
             )
         })?;
 
-    // Validate the store field type is Arc<RwLock<...>>
+    // Validate the store field type is Arc<tokio::sync::RwLock<...>>
     if !matches!(store_field.ty, syn::Type::Path(_)) {
         return Err(syn::Error::new(
             store_field.ty.span(),
-            "`store` field must be of type Arc<RwLock<S>>",
+            "`store` field must be of type Arc<tokio::sync::RwLock<S>>",
         ));
     }
 
@@ -119,7 +119,7 @@ fn expand_inner(args: ServiceArgs, item_struct: ItemStruct) -> Result<proc_macro
 
     let new_fn = if args.generate_new {
         Some(quote! {
-            pub fn new(store: std::sync::Arc<std::sync::RwLock<#type_ident>>) -> Self {
+            pub fn new(store: std::sync::Arc<tokio::sync::RwLock<#type_ident>>) -> Self {
                 Self { store }
             }
         })
@@ -127,26 +127,26 @@ fn expand_inner(args: ServiceArgs, item_struct: ItemStruct) -> Result<proc_macro
         None
     };
 
+    // The lock is `tokio::sync::RwLock` because the store traits are async: a
+    // service holding a `std::sync` guard across an `.await` blocks a runtime
+    // thread, and its futures are not `Send`. The accessors are therefore
+    // async too, and there is no poisoning to report.
     let expanded = quote! {
         #item_struct
 
         impl #impl_generics #struct_ident #ty_generics #where_clause {
             #new_fn
 
-            pub fn store(&self) -> &std::sync::Arc<std::sync::RwLock<#type_ident>> {
+            pub fn store(&self) -> &std::sync::Arc<tokio::sync::RwLock<#type_ident>> {
                 &self.store
             }
 
-            fn read_store(&self) -> std::sync::RwLockReadGuard<'_, #type_ident> {
-                self.store
-                    .read()
-                    .expect("store read lock poisoned")
+            async fn read_store(&self) -> tokio::sync::RwLockReadGuard<'_, #type_ident> {
+                self.store.read().await
             }
 
-            fn write_store(&self) -> std::sync::RwLockWriteGuard<'_, #type_ident> {
-                self.store
-                    .write()
-                    .expect("store write lock poisoned")
+            async fn write_store(&self) -> tokio::sync::RwLockWriteGuard<'_, #type_ident> {
+                self.store.write().await
             }
         }
     };

--- a/crates/wami-macros/src/service_attr.rs
+++ b/crates/wami-macros/src/service_attr.rs
@@ -153,3 +153,66 @@ fn expand_inner(args: ServiceArgs, item_struct: ItemStruct) -> Result<proc_macro
 
     Ok(expanded)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args() -> ServiceArgs {
+        ServiceArgs {
+            store_trait: parse_quote!(MyStore),
+            generate_new: true,
+        }
+    }
+
+    #[test]
+    fn a_store_field_that_is_not_a_path_type_is_refused() {
+        // A tuple, a reference, a pointer — anything the generated accessors
+        // cannot call `.read().await` on. Rejected with the shape it wanted,
+        // rather than by whatever the expansion would have failed on later.
+        let item: ItemStruct = parse_quote! {
+            struct Svc<S> { store: (S, S) }
+        };
+
+        let err = expand_inner(args(), item).unwrap_err();
+        assert!(
+            err.to_string().contains("Arc<tokio::sync::RwLock<S>>"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn a_struct_without_a_store_field_is_refused() {
+        let item: ItemStruct = parse_quote! {
+            struct Svc<S> { other: S }
+        };
+
+        let err = expand_inner(args(), item).unwrap_err();
+        assert!(err.to_string().contains("`store` field"), "{err}");
+    }
+
+    #[test]
+    fn a_non_generic_struct_is_refused() {
+        let item: ItemStruct = parse_quote! {
+            struct Svc { store: std::sync::Arc<tokio::sync::RwLock<Concrete>> }
+        };
+
+        let err = expand_inner(args(), item).unwrap_err();
+        assert!(err.to_string().contains("generic over `S`"), "{err}");
+    }
+
+    #[test]
+    fn the_generated_accessors_are_async_and_tokio() {
+        // The point of #115: were these to go back to `std::sync`, every
+        // service would hold a blocking guard across an await again.
+        let item: ItemStruct = parse_quote! {
+            struct Svc<S> { store: std::sync::Arc<tokio::sync::RwLock<S>> }
+        };
+
+        let expanded = expand_inner(args(), item).unwrap().to_string();
+        assert!(expanded.contains("async fn read_store"), "{expanded}");
+        assert!(expanded.contains("async fn write_store"), "{expanded}");
+        assert!(expanded.contains("tokio :: sync :: RwLock"), "{expanded}");
+        assert!(!expanded.contains("std :: sync :: RwLock"), "{expanded}");
+    }
+}

--- a/crates/wami/examples/03_service_layer_intro.rs
+++ b/crates/wami/examples/03_service_layer_intro.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 03_service_layer_intro`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::{GroupService, RoleService, UserService};

--- a/crates/wami/examples/04_simple_multi_tenant.rs
+++ b/crates/wami/examples/04_simple_multi_tenant.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 04_simple_multi_tenant`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::{TenantService, UserService};

--- a/crates/wami/examples/05_tenant_hierarchy.rs
+++ b/crates/wami/examples/05_tenant_hierarchy.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 05_tenant_hierarchy`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::TenantService;

--- a/crates/wami/examples/06_tenant_quotas_and_limits.rs
+++ b/crates/wami/examples/06_tenant_quotas_and_limits.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 06_tenant_quotas_and_limits`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::TenantService;

--- a/crates/wami/examples/07_cross_tenant_role_assumption.rs
+++ b/crates/wami/examples/07_cross_tenant_role_assumption.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 07_cross_tenant_role_assumption`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::{AssumeRoleService, RoleService, TenantService, UserService};

--- a/crates/wami/examples/08_tenant_migration.rs
+++ b/crates/wami/examples/08_tenant_migration.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 08_tenant_migration`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::{GroupService, TenantService, UserService};

--- a/crates/wami/examples/09_multi_cloud_user_sync.rs
+++ b/crates/wami/examples/09_multi_cloud_user_sync.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 09_multi_cloud_user_sync`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::UserService;

--- a/crates/wami/examples/10_provider_switching.rs
+++ b/crates/wami/examples/10_provider_switching.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 10_provider_switching`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::UserService;

--- a/crates/wami/examples/11_hybrid_cloud_setup.rs
+++ b/crates/wami/examples/11_hybrid_cloud_setup.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 11_hybrid_cloud_setup`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::error::Result;
 use wami::provider::{AwsProvider, CloudProvider, ResourceLimits, ResourceType};
 use wami::service::UserService;

--- a/crates/wami/examples/12_provider_specific_features.rs
+++ b/crates/wami/examples/12_provider_specific_features.rs
@@ -10,7 +10,8 @@
 //!
 //! Run with: `cargo run --example 12_provider_specific_features`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::RoleService;

--- a/crates/wami/examples/13_disaster_recovery_multi_cloud.rs
+++ b/crates/wami/examples/13_disaster_recovery_multi_cloud.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 13_disaster_recovery_multi_cloud`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::{GroupService, UserService};

--- a/crates/wami/examples/14_policy_basics.rs
+++ b/crates/wami/examples/14_policy_basics.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 14_policy_basics`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::{PolicyService, UserService};

--- a/crates/wami/examples/15_policy_evaluation_simulation.rs
+++ b/crates/wami/examples/15_policy_evaluation_simulation.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 15_policy_evaluation_simulation`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::{EvaluationService, UserService};

--- a/crates/wami/examples/16_role_based_access_control.rs
+++ b/crates/wami/examples/16_role_based_access_control.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 16_role_based_access_control`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::{PolicyService, RoleService, UserService};

--- a/crates/wami/examples/17_attribute_based_access_control.rs
+++ b/crates/wami/examples/17_attribute_based_access_control.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 17_attribute_based_access_control`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::{PolicyService, UserService};

--- a/crates/wami/examples/18_session_tokens.rs
+++ b/crates/wami/examples/18_session_tokens.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 18_session_tokens`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::{SessionTokenService, UserService};

--- a/crates/wami/examples/19_role_assumption_workflow.rs
+++ b/crates/wami/examples/19_role_assumption_workflow.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 19_role_assumption_workflow`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::{AssumeRoleService, RoleService, UserService};

--- a/crates/wami/examples/20_federated_access.rs
+++ b/crates/wami/examples/20_federated_access.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 20_federated_access`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::{FederationService, UserService};

--- a/crates/wami/examples/21_sso_setup_basic.rs
+++ b/crates/wami/examples/21_sso_setup_basic.rs
@@ -9,7 +9,8 @@
 //!
 //! Run with: `cargo run --example 21_sso_setup_basic`
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::provider::AwsProvider;
 use wami::service::{InstanceService as SsoInstanceService, PermissionSetService};
 use wami::store::memory::InMemoryWamiStore;

--- a/crates/wami/examples/22_identity_providers_federation.rs
+++ b/crates/wami/examples/22_identity_providers_federation.rs
@@ -12,7 +12,8 @@
 //!
 //! Run with: cargo run --example 22_identity_providers_federation
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::IdentityProviderService;

--- a/crates/wami/examples/23_permissions_boundaries.rs
+++ b/crates/wami/examples/23_permissions_boundaries.rs
@@ -10,7 +10,8 @@
 //!
 //! Run with: cargo run --example 23_permissions_boundaries
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::{
     arn::{TenantPath, WamiArn},
     context::WamiContext,

--- a/crates/wami/examples/24_policy_attachment.rs
+++ b/crates/wami/examples/24_policy_attachment.rs
@@ -3,7 +3,8 @@
 //! This example demonstrates how to attach managed policies and inline policies
 //! to users, groups, and roles.
 
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami::arn::{TenantPath, WamiArn};
 use wami::context::WamiContext;
 use wami::service::{AttachmentService, InlinePolicyService, PolicyService, UserService};

--- a/crates/wami/examples/26_secure_instance_bootstrap.rs
+++ b/crates/wami/examples/26_secure_instance_bootstrap.rs
@@ -20,7 +20,10 @@
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use wami::store::memory::InMemoryWamiStore;
-use wami::{AmiError, AuthenticationService, InstanceBootstrap, RootCredentials};
+use wami::{
+    AmiError, AuthenticationService, CreateUserRequest, InstanceBootstrap, RootCredentials,
+    UserService,
+};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -78,15 +81,23 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // =========================================================================
     println!("\n👤 Step 4: Create Admin User (as root)");
 
-    // Note: To create users, you would use UserService with the authenticated context
-    // Example:
-    // use wami::UserService;
-    // use std::sync::{Arc, RwLock as StdRwLock};
-    // let std_store = Arc::new(StdRwLock::new(store.read().await.wami_store.clone()));
-    // let user_service = UserService::new(std_store);
-    // let admin_user = user_service.create_user(&root_context, ...).await?;
+    // The same store handle that bootstrapped the instance and authenticated
+    // the caller also serves UserService — one lock type, one source of truth.
+    let user_service = UserService::new(store.clone());
+    let admin_user = user_service
+        .create_user(
+            &root_context,
+            CreateUserRequest {
+                user_name: "admin".to_string(),
+                path: Some("/".to_string()),
+                permissions_boundary: None,
+                tags: None,
+            },
+        )
+        .await?;
 
-    println!("✅ Root context can be used to create resources");
+    println!("✅ Admin user created: {}", admin_user.user_name);
+    println!("   ARN:              {}", admin_user.wami_arn);
     println!("   Context is required for all operations");
     println!("   Root context bypasses authorization checks");
 

--- a/crates/wami/src/service/credentials/access_key.rs
+++ b/crates/wami/src/service/credentials/access_key.rs
@@ -4,7 +4,8 @@
 
 use crate::service::auth::authorizer::{iam_resource_arn, Authorizer};
 use crate::store::traits::AccessKeyStore;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::Result;
@@ -73,7 +74,7 @@ impl<S: AccessKeyStore> AccessKeyService<S> {
         let access_key = access_key_builder::build_access_key(request.user_name, context)?;
 
         // Store it
-        self.write_store().create_access_key(access_key).await
+        self.write_store().await.create_access_key(access_key).await
     }
 
     /// Get an access key by ID
@@ -89,7 +90,7 @@ impl<S: AccessKeyStore> AccessKeyService<S> {
             access_key_id,
         )
         .await?;
-        self.read_store().get_access_key(access_key_id).await
+        self.read_store().await.get_access_key(access_key_id).await
     }
 
     /// Update an access key (e.g., change status)
@@ -105,7 +106,7 @@ impl<S: AccessKeyStore> AccessKeyService<S> {
             &access_key.user_name,
         )
         .await?;
-        self.write_store().update_access_key(access_key).await
+        self.write_store().await.update_access_key(access_key).await
     }
 
     /// Delete an access key
@@ -121,7 +122,10 @@ impl<S: AccessKeyStore> AccessKeyService<S> {
             access_key_id,
         )
         .await?;
-        self.write_store().delete_access_key(access_key_id).await
+        self.write_store()
+            .await
+            .delete_access_key(access_key_id)
+            .await
     }
 
     /// List access keys for a user
@@ -138,6 +142,7 @@ impl<S: AccessKeyStore> AccessKeyService<S> {
         )
         .await?;
         self.read_store()
+            .await
             .list_access_keys(&request.user_name, request.pagination.as_ref())
             .await
     }

--- a/crates/wami/src/service/credentials/login_profile.rs
+++ b/crates/wami/src/service/credentials/login_profile.rs
@@ -4,7 +4,8 @@
 
 use crate::service::auth::authorizer::{iam_resource_arn, Authorizer};
 use crate::store::traits::LoginProfileStore;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::Result;
@@ -78,7 +79,10 @@ impl<S: LoginProfileStore> LoginProfileService<S> {
         )?;
 
         // Store it
-        self.write_store().create_login_profile(login_profile).await
+        self.write_store()
+            .await
+            .create_login_profile(login_profile)
+            .await
     }
 
     /// Get a login profile for a user
@@ -89,7 +93,7 @@ impl<S: LoginProfileStore> LoginProfileService<S> {
     ) -> Result<Option<LoginProfile>> {
         self.guard(context, WamiAction::IamManageCredentials, "user", user_name)
             .await?;
-        self.read_store().get_login_profile(user_name).await
+        self.read_store().await.get_login_profile(user_name).await
     }
 
     /// Update a login profile
@@ -109,6 +113,7 @@ impl<S: LoginProfileStore> LoginProfileService<S> {
         // Get existing profile
         let profile = self
             .read_store()
+            .await
             .get_login_profile(&request.user_name)
             .await?
             .ok_or_else(|| crate::error::AmiError::ResourceNotFound {
@@ -122,6 +127,7 @@ impl<S: LoginProfileStore> LoginProfileService<S> {
 
         // Store updated profile
         self.write_store()
+            .await
             .update_login_profile(updated_profile)
             .await
     }
@@ -130,7 +136,10 @@ impl<S: LoginProfileStore> LoginProfileService<S> {
     pub async fn delete_login_profile(&self, context: &WamiContext, user_name: &str) -> Result<()> {
         self.guard(context, WamiAction::IamManageCredentials, "user", user_name)
             .await?;
-        self.write_store().delete_login_profile(user_name).await
+        self.write_store()
+            .await
+            .delete_login_profile(user_name)
+            .await
     }
 }
 

--- a/crates/wami/src/service/credentials/mfa_device.rs
+++ b/crates/wami/src/service/credentials/mfa_device.rs
@@ -4,7 +4,8 @@
 
 use crate::service::auth::authorizer::{iam_resource_arn, Authorizer};
 use crate::store::traits::MfaDeviceStore;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::Result;
@@ -74,7 +75,7 @@ impl<S: MfaDeviceStore> MfaDeviceService<S> {
             mfa_builder::build_mfa_device(request.user_name, request.serial_number, context)?;
 
         // Store it
-        self.write_store().create_mfa_device(mfa_device).await
+        self.write_store().await.create_mfa_device(mfa_device).await
     }
 
     /// Get an MFA device by serial number
@@ -90,7 +91,7 @@ impl<S: MfaDeviceStore> MfaDeviceService<S> {
             serial_number,
         )
         .await?;
-        self.read_store().get_mfa_device(serial_number).await
+        self.read_store().await.get_mfa_device(serial_number).await
     }
 
     /// Delete an MFA device
@@ -106,7 +107,10 @@ impl<S: MfaDeviceStore> MfaDeviceService<S> {
             serial_number,
         )
         .await?;
-        self.write_store().delete_mfa_device(serial_number).await
+        self.write_store()
+            .await
+            .delete_mfa_device(serial_number)
+            .await
     }
 
     /// List MFA devices for a user
@@ -122,7 +126,10 @@ impl<S: MfaDeviceStore> MfaDeviceService<S> {
             &request.user_name,
         )
         .await?;
-        self.read_store().list_mfa_devices(&request.user_name).await
+        self.read_store()
+            .await
+            .list_mfa_devices(&request.user_name)
+            .await
     }
 }
 

--- a/crates/wami/src/service/credentials/server_certificate.rs
+++ b/crates/wami/src/service/credentials/server_certificate.rs
@@ -253,6 +253,67 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_update_server_certificate() {
+        let service = setup_service();
+        let context = test_context();
+
+        service
+            .upload_server_certificate(
+                &context,
+                UploadServerCertificateRequest {
+                    server_certificate_name: "test-cert".to_string(),
+                    certificate_body:
+                        "-----BEGIN CERTIFICATE-----\ntest\n-----END CERTIFICATE-----".to_string(),
+                    private_key:
+                        "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----"
+                            .to_string(),
+                    certificate_chain: None,
+                    path: Some("/certs/".to_string()),
+                    tags: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        // Renaming is not exercised here: the in-memory store looks the entry up
+        // by the *new* name, so a rename cannot find it. That is a store bug,
+        // untouched by this change.
+        let updated = service
+            .update_server_certificate(
+                &context,
+                UpdateServerCertificateRequest {
+                    server_certificate_name: "test-cert".to_string(),
+                    new_server_certificate_name: None,
+                    new_path: Some("/renamed/".to_string()),
+                },
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(updated.server_certificate_name, "test-cert");
+        assert_eq!(updated.path, "/renamed/");
+    }
+
+    #[tokio::test]
+    async fn test_update_server_certificate_not_found() {
+        let service = setup_service();
+        let context = test_context();
+
+        let result = service
+            .update_server_certificate(
+                &context,
+                UpdateServerCertificateRequest {
+                    server_certificate_name: "missing".to_string(),
+                    new_server_certificate_name: None,
+                    new_path: None,
+                },
+            )
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
     async fn test_delete_server_certificate() {
         let service = setup_service();
         let context = test_context();

--- a/crates/wami/src/service/credentials/server_certificate.rs
+++ b/crates/wami/src/service/credentials/server_certificate.rs
@@ -4,7 +4,8 @@
 
 use crate::service::auth::authorizer::{iam_resource_arn, Authorizer};
 use crate::store::traits::ServerCertificateStore;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::Result;
@@ -83,6 +84,7 @@ impl<S: ServerCertificateStore> ServerCertificateService<S> {
 
         // Store it (note: private_key is part of ServerCertificate, not passed separately)
         self.write_store()
+            .await
             .create_server_certificate(certificate)
             .await
     }
@@ -101,6 +103,7 @@ impl<S: ServerCertificateStore> ServerCertificateService<S> {
         )
         .await?;
         self.read_store()
+            .await
             .get_server_certificate(certificate_name)
             .await
     }
@@ -122,6 +125,7 @@ impl<S: ServerCertificateStore> ServerCertificateService<S> {
         // Get existing certificate
         let mut certificate = self
             .read_store()
+            .await
             .get_server_certificate(&request.server_certificate_name)
             .await?
             .ok_or_else(|| crate::error::AmiError::ResourceNotFound {
@@ -139,6 +143,7 @@ impl<S: ServerCertificateStore> ServerCertificateService<S> {
 
         // Store updated certificate
         self.write_store()
+            .await
             .update_server_certificate(certificate)
             .await
     }
@@ -157,6 +162,7 @@ impl<S: ServerCertificateStore> ServerCertificateService<S> {
         )
         .await?;
         self.write_store()
+            .await
             .delete_server_certificate(certificate_name)
             .await
     }
@@ -180,6 +186,7 @@ impl<S: ServerCertificateStore> ServerCertificateService<S> {
         };
 
         self.read_store()
+            .await
             .list_server_certificates(request.path_prefix.as_deref(), pagination.as_ref())
             .await
     }

--- a/crates/wami/src/service/credentials/service_credential.rs
+++ b/crates/wami/src/service/credentials/service_credential.rs
@@ -4,7 +4,8 @@
 
 use crate::service::auth::authorizer::{iam_resource_arn, Authorizer};
 use crate::store::traits::ServiceCredentialStore;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::Result;
@@ -80,6 +81,7 @@ impl<S: ServiceCredentialStore> ServiceCredentialService<S> {
 
         // Store it
         self.write_store()
+            .await
             .create_service_specific_credential(credential)
             .await
     }
@@ -98,6 +100,7 @@ impl<S: ServiceCredentialStore> ServiceCredentialService<S> {
         )
         .await?;
         self.read_store()
+            .await
             .get_service_specific_credential(credential_id)
             .await
     }
@@ -119,6 +122,7 @@ impl<S: ServiceCredentialStore> ServiceCredentialService<S> {
         // Get existing credential
         let mut credential = self
             .read_store()
+            .await
             .get_service_specific_credential(&request.service_specific_credential_id)
             .await?
             .ok_or_else(|| crate::error::AmiError::ResourceNotFound {
@@ -133,6 +137,7 @@ impl<S: ServiceCredentialStore> ServiceCredentialService<S> {
 
         // Store updated credential
         self.write_store()
+            .await
             .update_service_specific_credential(credential)
             .await
     }
@@ -151,6 +156,7 @@ impl<S: ServiceCredentialStore> ServiceCredentialService<S> {
         )
         .await?;
         self.write_store()
+            .await
             .delete_service_specific_credential(&request.service_specific_credential_id)
             .await
     }
@@ -170,6 +176,7 @@ impl<S: ServiceCredentialStore> ServiceCredentialService<S> {
         )
         .await?;
         self.read_store()
+            .await
             .list_service_specific_credentials(user_name)
             .await
     }

--- a/crates/wami/src/service/credentials/signing_certificate.rs
+++ b/crates/wami/src/service/credentials/signing_certificate.rs
@@ -4,7 +4,8 @@
 
 use crate::service::auth::authorizer::{iam_resource_arn, Authorizer};
 use crate::store::traits::SigningCertificateStore;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::Result;
@@ -79,6 +80,7 @@ impl<S: SigningCertificateStore> SigningCertificateService<S> {
 
         // Store it
         self.write_store()
+            .await
             .create_signing_certificate(certificate)
             .await
     }
@@ -97,6 +99,7 @@ impl<S: SigningCertificateStore> SigningCertificateService<S> {
         )
         .await?;
         self.read_store()
+            .await
             .get_signing_certificate(certificate_id)
             .await
     }
@@ -118,6 +121,7 @@ impl<S: SigningCertificateStore> SigningCertificateService<S> {
         // Get existing certificate
         let mut certificate = self
             .read_store()
+            .await
             .get_signing_certificate(&request.certificate_id)
             .await?
             .ok_or_else(|| crate::error::AmiError::ResourceNotFound {
@@ -129,6 +133,7 @@ impl<S: SigningCertificateStore> SigningCertificateService<S> {
 
         // Store updated certificate
         self.write_store()
+            .await
             .update_signing_certificate(certificate)
             .await
     }
@@ -147,6 +152,7 @@ impl<S: SigningCertificateStore> SigningCertificateService<S> {
         )
         .await?;
         self.write_store()
+            .await
             .delete_signing_certificate(&request.certificate_id)
             .await
     }
@@ -161,6 +167,7 @@ impl<S: SigningCertificateStore> SigningCertificateService<S> {
         self.guard(context, WamiAction::IamManageCredentials, "user", user_name)
             .await?;
         self.read_store()
+            .await
             .list_signing_certificates(request.user_name.as_deref())
             .await
     }

--- a/crates/wami/src/service/gdpr/mod.rs
+++ b/crates/wami/src/service/gdpr/mod.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::await_holding_lock)]
 //! GDPR Service
 //!
 //! Orchestrates consent management, audit trail recording, data export,
@@ -11,7 +10,8 @@ use crate::wami::gdpr::model::{
 };
 use crate::wami::gdpr::operations;
 use chrono::Utc;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::error::{AmiError, Result};
 
 /// Combined trait bound for GDPR storage.
@@ -49,13 +49,17 @@ impl<S: GdprStore> GdprService<S> {
 
         // Revoke any existing active consent for this user+category.
         // Note: split into two statements to drop the read lock before acquiring write lock
-        // (std::sync::RwLock deadlocks if both held on the same thread).
+        // (the RwLock is not reentrant — holding both at once deadlocks the task).
         let existing = self
             .read_store()
+            .await
             .get_active_consent(tenant_id, user_name, category)
             .await?;
         if let Some(existing) = existing {
-            self.write_store().revoke_consent(&existing.id).await?;
+            self.write_store()
+                .await
+                .revoke_consent(&existing.id)
+                .await?;
         }
 
         // Create the new consent record.
@@ -73,12 +77,12 @@ impl<S: GdprStore> GdprService<S> {
             active: true,
         };
 
-        let created = self.write_store().create_consent(record).await?;
+        let created = self.write_store().await.create_consent(record).await?;
 
         // Audit trail.
         let audit_event =
             operations::build_consent_audit_event(tenant_id, user_name, user_name, category, level);
-        self.write_store().record_event(audit_event).await?;
+        self.write_store().await.record_event(audit_event).await?;
 
         Ok(created)
     }
@@ -92,6 +96,7 @@ impl<S: GdprStore> GdprService<S> {
     ) -> Result<()> {
         let existing = self
             .read_store()
+            .await
             .get_active_consent(tenant_id, user_name, category)
             .await?
             .ok_or_else(|| AmiError::ResourceNotFound {
@@ -101,7 +106,10 @@ impl<S: GdprStore> GdprService<S> {
                 ),
             })?;
 
-        self.write_store().revoke_consent(&existing.id).await?;
+        self.write_store()
+            .await
+            .revoke_consent(&existing.id)
+            .await?;
 
         // Audit trail.
         let event = WamiAuditEvent {
@@ -115,7 +123,7 @@ impl<S: GdprStore> GdprService<S> {
             source_ip: None,
             metadata: None,
         };
-        self.write_store().record_event(event).await?;
+        self.write_store().await.record_event(event).await?;
 
         Ok(())
     }
@@ -124,6 +132,7 @@ impl<S: GdprStore> GdprService<S> {
     pub async fn revoke_all_consents(&self, tenant_id: &str, user_name: &str) -> Result<u64> {
         let count = self
             .write_store()
+            .await
             .revoke_all_user_consents(tenant_id, user_name)
             .await?;
 
@@ -138,7 +147,7 @@ impl<S: GdprStore> GdprService<S> {
             source_ip: None,
             metadata: Some(serde_json::json!({ "revoked_count": count })),
         };
-        self.write_store().record_event(event).await?;
+        self.write_store().await.record_event(event).await?;
 
         Ok(count)
     }
@@ -150,6 +159,7 @@ impl<S: GdprStore> GdprService<S> {
         user_name: &str,
     ) -> Result<Vec<ConsentRecord>> {
         self.read_store()
+            .await
             .list_user_consents(tenant_id, user_name)
             .await
     }
@@ -163,6 +173,7 @@ impl<S: GdprStore> GdprService<S> {
     ) -> Result<bool> {
         let consents = self
             .read_store()
+            .await
             .list_user_consents(tenant_id, user_name)
             .await?;
         Ok(operations::is_processing_allowed(&consents, category))
@@ -182,7 +193,11 @@ impl<S: GdprStore> GdprService<S> {
         processed_by: &str,
     ) -> Result<ErasureCertificate> {
         // Get retention policies to determine what must be retained.
-        let policies = self.read_store().list_retention_policies(tenant_id).await?;
+        let policies = self
+            .read_store()
+            .await
+            .list_retention_policies(tenant_id)
+            .await?;
 
         let (to_erase, to_retain) = operations::compute_erasure_scope(categories, &policies);
 
@@ -213,18 +228,20 @@ impl<S: GdprStore> GdprService<S> {
 
         let saved = self
             .write_store()
+            .await
             .create_erasure_certificate(certificate.clone())
             .await?;
 
         // Revoke all consents for erased user.
         let _ = self
             .write_store()
+            .await
             .revoke_all_user_consents(tenant_id, user_name)
             .await;
 
         // Audit trail.
         let audit_event = operations::build_erasure_audit_event(tenant_id, processed_by, &saved);
-        self.write_store().record_event(audit_event).await?;
+        self.write_store().await.record_event(audit_event).await?;
 
         Ok(saved)
     }
@@ -235,6 +252,7 @@ impl<S: GdprStore> GdprService<S> {
         certificate_id: &str,
     ) -> Result<Option<ErasureCertificate>> {
         self.read_store()
+            .await
             .get_erasure_certificate(certificate_id)
             .await
     }
@@ -250,6 +268,7 @@ impl<S: GdprStore> GdprService<S> {
     ) -> Result<UserDataExport> {
         let export = self
             .read_store()
+            .await
             .export_user_data(tenant_id, user_name, categories)
             .await?;
 
@@ -268,7 +287,7 @@ impl<S: GdprStore> GdprService<S> {
                 "section_count": export.sections.len(),
             })),
         };
-        self.write_store().record_event(event).await?;
+        self.write_store().await.record_event(event).await?;
 
         Ok(export)
     }
@@ -280,17 +299,27 @@ impl<S: GdprStore> GdprService<S> {
         &self,
         policy: RetentionPolicy,
     ) -> Result<RetentionPolicy> {
-        self.write_store().upsert_retention_policy(policy).await
+        self.write_store()
+            .await
+            .upsert_retention_policy(policy)
+            .await
     }
 
     /// List retention policies for a tenant.
     pub async fn list_retention_policies(&self, tenant_id: &str) -> Result<Vec<RetentionPolicy>> {
-        self.read_store().list_retention_policies(tenant_id).await
+        self.read_store()
+            .await
+            .list_retention_policies(tenant_id)
+            .await
     }
 
     /// Enforce retention policies (purge expired data).
     pub async fn enforce_retention(&self, tenant_id: &str) -> Result<u64> {
-        let count = self.write_store().enforce_retention(tenant_id).await?;
+        let count = self
+            .write_store()
+            .await
+            .enforce_retention(tenant_id)
+            .await?;
 
         if count > 0 {
             let event = WamiAuditEvent {
@@ -304,7 +333,7 @@ impl<S: GdprStore> GdprService<S> {
                 source_ip: None,
                 metadata: Some(serde_json::json!({ "records_purged": count })),
             };
-            self.write_store().record_event(event).await?;
+            self.write_store().await.record_event(event).await?;
         }
 
         Ok(count)
@@ -318,7 +347,10 @@ impl<S: GdprStore> GdprService<S> {
         tenant_id: &str,
         filter: &crate::store::traits::gdpr::audit::AuditFilter,
     ) -> Result<Vec<WamiAuditEvent>> {
-        self.read_store().query_events(tenant_id, filter).await
+        self.read_store()
+            .await
+            .query_events(tenant_id, filter)
+            .await
     }
 }
 
@@ -872,7 +904,7 @@ mod tests {
         let svc = make_service();
         // Create a consent with an old granted_at date
         {
-            let mut store = svc.write_store();
+            let mut store = svc.write_store().await;
             store.consents.push(ConsentRecord {
                 id: "old-c1".to_string(),
                 user_name: "alice".to_string(),
@@ -939,7 +971,7 @@ mod tests {
     async fn enforce_retention_emits_audit_when_purging() {
         let svc = make_service();
         {
-            let mut store = svc.write_store();
+            let mut store = svc.write_store().await;
             store.consents.push(ConsentRecord {
                 id: "old-c1".to_string(),
                 user_name: "bob".to_string(),

--- a/crates/wami/src/service/identity/group.rs
+++ b/crates/wami/src/service/identity/group.rs
@@ -7,7 +7,8 @@ use crate::store::traits::GroupStore;
 use crate::wami::identity::group::{
     builder as group_builder, CreateGroupRequest, Group, ListGroupsRequest, UpdateGroupRequest,
 };
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::Result;
@@ -64,7 +65,7 @@ impl<S: GroupStore> GroupService<S> {
         .await?;
 
         let group = group_builder::build_group(request.group_name, request.path, context)?;
-        self.write_store().create_group(group).await
+        self.write_store().await.create_group(group).await
     }
 
     /// Get a group by name
@@ -75,7 +76,7 @@ impl<S: GroupStore> GroupService<S> {
     ) -> Result<Option<Group>> {
         self.guard(context, WamiAction::IamReadRole, "group", group_name)
             .await?;
-        self.read_store().get_group(group_name).await
+        self.read_store().await.get_group(group_name).await
     }
 
     /// Update a group
@@ -94,6 +95,7 @@ impl<S: GroupStore> GroupService<S> {
 
         let mut group = self
             .read_store()
+            .await
             .get_group(&request.group_name)
             .await?
             .ok_or_else(|| crate::error::AmiError::ResourceNotFound {
@@ -108,14 +110,14 @@ impl<S: GroupStore> GroupService<S> {
             group = group_builder::update_group_path(group, new_path);
         }
 
-        self.write_store().update_group(group).await
+        self.write_store().await.update_group(group).await
     }
 
     /// Delete a group
     pub async fn delete_group(&self, context: &WamiContext, group_name: &str) -> Result<()> {
         self.guard(context, WamiAction::IamDeleteGroup, "group", group_name)
             .await?;
-        self.write_store().delete_group(group_name).await
+        self.write_store().await.delete_group(group_name).await
     }
 
     /// List groups with optional filtering
@@ -127,6 +129,7 @@ impl<S: GroupStore> GroupService<S> {
         self.guard(context, WamiAction::IamListUsers, "group", "*")
             .await?;
         self.read_store()
+            .await
             .list_groups(request.path_prefix.as_deref(), request.pagination.as_ref())
             .await
     }
@@ -146,6 +149,7 @@ impl<S: GroupStore> GroupService<S> {
         )
         .await?;
         self.write_store()
+            .await
             .add_user_to_group(group_name, user_name)
             .await
     }
@@ -165,6 +169,7 @@ impl<S: GroupStore> GroupService<S> {
         )
         .await?;
         self.write_store()
+            .await
             .remove_user_from_group(group_name, user_name)
             .await
     }
@@ -177,7 +182,10 @@ impl<S: GroupStore> GroupService<S> {
     ) -> Result<Vec<Group>> {
         self.guard(context, WamiAction::IamReadUser, "user", user_name)
             .await?;
-        self.read_store().list_groups_for_user(user_name).await
+        self.read_store()
+            .await
+            .list_groups_for_user(user_name)
+            .await
     }
 }
 
@@ -304,7 +312,7 @@ mod tests {
 
         let user =
             user_builder::build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
-        store.write().unwrap().create_user(user).await.unwrap();
+        store.write().await.create_user(user).await.unwrap();
 
         let request = CreateGroupRequest {
             group_name: "admins".to_string(),

--- a/crates/wami/src/service/identity/identity_provider.rs
+++ b/crates/wami/src/service/identity/identity_provider.rs
@@ -10,7 +10,8 @@ use crate::wami::identity::identity_provider::{
     RemoveClientIDFromOpenIDConnectProviderRequest, SamlProvider,
     UpdateOpenIDConnectProviderThumbprintRequest, UpdateSAMLProviderRequest,
 };
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::context::WamiContext;
 use wami_core::error::{AmiError, Result};
 use wami_core::types::Tag;
@@ -60,13 +61,13 @@ impl<S: IdentityProviderStore> IdentityProviderService<S> {
         }
 
         // Persist
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
         store.create_saml_provider(provider).await
     }
 
     /// Get a SAML provider by ARN
     pub async fn get_saml_provider(&self, arn: &str) -> Result<Option<SamlProvider>> {
-        let store = self.read_store();
+        let store = self.read_store().await;
         store.get_saml_provider(arn).await
     }
 
@@ -80,7 +81,7 @@ impl<S: IdentityProviderStore> IdentityProviderService<S> {
 
         // Get existing provider
         let existing = {
-            let store = self.read_store();
+            let store = self.read_store().await;
             store.get_saml_provider(&request.arn).await?
         };
 
@@ -100,13 +101,13 @@ impl<S: IdentityProviderStore> IdentityProviderService<S> {
         }
 
         // Persist
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
         store.update_saml_provider(updated).await
     }
 
     /// Delete a SAML provider
     pub async fn delete_saml_provider(&self, arn: &str) -> Result<()> {
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
         store.delete_saml_provider(arn).await
     }
 
@@ -115,7 +116,7 @@ impl<S: IdentityProviderStore> IdentityProviderService<S> {
         &self,
         request: ListSAMLProvidersRequest,
     ) -> Result<(Vec<SamlProvider>, bool, Option<String>)> {
-        let store = self.read_store();
+        let store = self.read_store().await;
         store.list_saml_providers(request.pagination.as_ref()).await
     }
 
@@ -152,13 +153,13 @@ impl<S: IdentityProviderStore> IdentityProviderService<S> {
         }
 
         // Persist
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
         store.create_oidc_provider(provider).await
     }
 
     /// Get an OIDC provider by ARN
     pub async fn get_oidc_provider(&self, arn: &str) -> Result<Option<OidcProvider>> {
-        let store = self.read_store();
+        let store = self.read_store().await;
         store.get_oidc_provider(arn).await
     }
 
@@ -172,7 +173,7 @@ impl<S: IdentityProviderStore> IdentityProviderService<S> {
 
         // Get existing provider
         let existing = {
-            let store = self.read_store();
+            let store = self.read_store().await;
             store.get_oidc_provider(&request.arn).await?
         };
 
@@ -184,7 +185,7 @@ impl<S: IdentityProviderStore> IdentityProviderService<S> {
         let updated = builder::update_thumbprints(existing, request.thumbprint_list);
 
         // Persist
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
         store.update_oidc_provider(updated).await
     }
 
@@ -195,7 +196,7 @@ impl<S: IdentityProviderStore> IdentityProviderService<S> {
     ) -> Result<OidcProvider> {
         // Get existing provider
         let existing = {
-            let store = self.read_store();
+            let store = self.read_store().await;
             store.get_oidc_provider(&request.arn).await?
         };
 
@@ -207,7 +208,7 @@ impl<S: IdentityProviderStore> IdentityProviderService<S> {
         let updated = builder::add_client_id(existing, request.client_id);
 
         // Persist
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
         store.update_oidc_provider(updated).await
     }
 
@@ -218,7 +219,7 @@ impl<S: IdentityProviderStore> IdentityProviderService<S> {
     ) -> Result<OidcProvider> {
         // Get existing provider
         let existing = {
-            let store = self.read_store();
+            let store = self.read_store().await;
             store.get_oidc_provider(&request.arn).await?
         };
 
@@ -230,13 +231,13 @@ impl<S: IdentityProviderStore> IdentityProviderService<S> {
         let updated = builder::remove_client_id(existing, &request.client_id);
 
         // Persist
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
         store.update_oidc_provider(updated).await
     }
 
     /// Delete an OIDC provider
     pub async fn delete_oidc_provider(&self, arn: &str) -> Result<()> {
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
         store.delete_oidc_provider(arn).await
     }
 
@@ -245,7 +246,7 @@ impl<S: IdentityProviderStore> IdentityProviderService<S> {
         &self,
         request: ListOpenIDConnectProvidersRequest,
     ) -> Result<(Vec<OidcProvider>, bool, Option<String>)> {
-        let store = self.read_store();
+        let store = self.read_store().await;
         store.list_oidc_providers(request.pagination.as_ref()).await
     }
 
@@ -255,19 +256,19 @@ impl<S: IdentityProviderStore> IdentityProviderService<S> {
 
     /// Tag an identity provider (SAML or OIDC)
     pub async fn tag_identity_provider(&self, arn: &str, tags: Vec<Tag>) -> Result<()> {
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
         store.tag_identity_provider(arn, tags).await
     }
 
     /// List tags for an identity provider
     pub async fn list_identity_provider_tags(&self, arn: &str) -> Result<Vec<Tag>> {
-        let store = self.read_store();
+        let store = self.read_store().await;
         store.list_identity_provider_tags(arn).await
     }
 
     /// Untag an identity provider
     pub async fn untag_identity_provider(&self, arn: &str, tag_keys: Vec<String>) -> Result<()> {
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
         store.untag_identity_provider(arn, tag_keys).await
     }
 }

--- a/crates/wami/src/service/identity/identity_provider.rs
+++ b/crates/wami/src/service/identity/identity_provider.rs
@@ -405,4 +405,68 @@ mod tests {
         let after_delete = service.get_oidc_provider(&created.arn).await.unwrap();
         assert!(after_delete.is_none());
     }
+
+    #[tokio::test]
+    async fn test_identity_provider_tagging() {
+        let store = Arc::new(RwLock::new(InMemoryWamiStore::default()));
+        let service = IdentityProviderService::new(store);
+        let context = test_context();
+
+        let created = service
+            .create_saml_provider(
+                &context,
+                CreateSAMLProviderRequest {
+                    name: "TaggedSAML".to_string(),
+                    saml_metadata_document: r#"<?xml version="1.0"?>
+                        <EntityDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata">
+                            <IDPSSODescriptor />
+                        </EntityDescriptor>"#
+                        .to_string(),
+                    tags: None,
+                },
+            )
+            .await
+            .unwrap();
+
+        assert!(service
+            .list_identity_provider_tags(&created.arn)
+            .await
+            .unwrap()
+            .is_empty());
+
+        service
+            .tag_identity_provider(
+                &created.arn,
+                vec![
+                    Tag {
+                        key: "env".to_string(),
+                        value: "prod".to_string(),
+                    },
+                    Tag {
+                        key: "team".to_string(),
+                        value: "platform".to_string(),
+                    },
+                ],
+            )
+            .await
+            .unwrap();
+
+        let tags = service
+            .list_identity_provider_tags(&created.arn)
+            .await
+            .unwrap();
+        assert_eq!(tags.len(), 2);
+
+        service
+            .untag_identity_provider(&created.arn, vec!["env".to_string()])
+            .await
+            .unwrap();
+
+        let remaining = service
+            .list_identity_provider_tags(&created.arn)
+            .await
+            .unwrap();
+        assert_eq!(remaining.len(), 1);
+        assert_eq!(remaining[0].key, "team");
+    }
 }

--- a/crates/wami/src/service/identity/role.rs
+++ b/crates/wami/src/service/identity/role.rs
@@ -7,7 +7,8 @@ use crate::store::traits::RoleStore;
 use crate::wami::identity::role::{
     builder as role_builder, CreateRoleRequest, ListRolesRequest, Role, UpdateRoleRequest,
 };
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::Result;
@@ -80,14 +81,14 @@ impl<S: RoleStore> RoleService<S> {
             role
         };
 
-        self.write_store().create_role(role).await
+        self.write_store().await.create_role(role).await
     }
 
     /// Get a role by name
     pub async fn get_role(&self, context: &WamiContext, role_name: &str) -> Result<Option<Role>> {
         self.guard(context, WamiAction::IamReadRole, "role", role_name)
             .await?;
-        self.read_store().get_role(role_name).await
+        self.read_store().await.get_role(role_name).await
     }
 
     /// Update a role
@@ -107,7 +108,7 @@ impl<S: RoleStore> RoleService<S> {
         let mut role = self
             .store
             .read()
-            .unwrap()
+            .await
             .get_role(&request.role_name)
             .await?
             .ok_or_else(|| crate::error::AmiError::ResourceNotFound {
@@ -122,14 +123,14 @@ impl<S: RoleStore> RoleService<S> {
             role = role_builder::update_max_session_duration(role, max_session_duration);
         }
 
-        self.write_store().update_role(role).await
+        self.write_store().await.update_role(role).await
     }
 
     /// Delete a role
     pub async fn delete_role(&self, context: &WamiContext, role_name: &str) -> Result<()> {
         self.guard(context, WamiAction::IamDeleteRole, "role", role_name)
             .await?;
-        self.write_store().delete_role(role_name).await
+        self.write_store().await.delete_role(role_name).await
     }
 
     /// List roles with optional filtering
@@ -142,7 +143,7 @@ impl<S: RoleStore> RoleService<S> {
             .await?;
         self.store
             .read()
-            .unwrap()
+            .await
             .list_roles(request.path_prefix.as_deref(), request.pagination.as_ref())
             .await
     }

--- a/crates/wami/src/service/identity/service_linked_role.rs
+++ b/crates/wami/src/service/identity/service_linked_role.rs
@@ -9,7 +9,8 @@ use crate::wami::identity::service_linked_role::{
     operations as slr_ops, CreateServiceLinkedRoleRequest, DeletionTaskInfo,
 };
 use crate::wami::identity::Role;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::Result;
@@ -96,7 +97,7 @@ impl<S: ServiceLinkedRoleServiceStore> ServiceLinkedRoleService<S> {
             context,
         )?;
 
-        self.write_store().create_role(role).await
+        self.write_store().await.create_role(role).await
     }
 
     /// Get the status of a service-linked role deletion task
@@ -109,7 +110,7 @@ impl<S: ServiceLinkedRoleServiceStore> ServiceLinkedRoleService<S> {
             .await?;
         self.store
             .read()
-            .unwrap()
+            .await
             .get_service_linked_role_deletion_task(deletion_task_id)
             .await
     }

--- a/crates/wami/src/service/identity/user.rs
+++ b/crates/wami/src/service/identity/user.rs
@@ -8,7 +8,8 @@ use crate::wami::identity::root_user::ROOT_USER_NAME;
 use crate::wami::identity::user::{
     builder as user_builder, CreateUserRequest, ListUsersRequest, UpdateUserRequest, User,
 };
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::{AmiError, Result};
@@ -84,14 +85,14 @@ impl<S: UserStore> UserService<S> {
         };
 
         // Store it
-        self.write_store().create_user(user).await
+        self.write_store().await.create_user(user).await
     }
 
     /// Get a user by name
     pub async fn get_user(&self, context: &WamiContext, user_name: &str) -> Result<Option<User>> {
         self.guard(context, WamiAction::IamReadUser, "user", user_name)
             .await?;
-        self.read_store().get_user(user_name).await
+        self.read_store().await.get_user(user_name).await
     }
 
     /// Update a user
@@ -125,7 +126,7 @@ impl<S: UserStore> UserService<S> {
         let mut user = self
             .store
             .read()
-            .unwrap()
+            .await
             .get_user(&request.user_name)
             .await?
             .ok_or_else(|| AmiError::ResourceNotFound {
@@ -142,7 +143,7 @@ impl<S: UserStore> UserService<S> {
         }
 
         // Store updated user
-        self.write_store().update_user(user).await
+        self.write_store().await.update_user(user).await
     }
 
     /// Delete a user
@@ -158,7 +159,7 @@ impl<S: UserStore> UserService<S> {
 
         self.guard(context, WamiAction::IamDeleteUser, "user", user_name)
             .await?;
-        self.write_store().delete_user(user_name).await
+        self.write_store().await.delete_user(user_name).await
     }
 
     /// List users with optional filtering
@@ -170,6 +171,7 @@ impl<S: UserStore> UserService<S> {
         self.guard(context, WamiAction::IamListUsers, "user", "*")
             .await?;
         self.read_store()
+            .await
             .list_users(request.path_prefix.as_deref(), request.pagination.as_ref())
             .await
     }
@@ -183,14 +185,14 @@ impl<S: UserStore> UserService<S> {
     ) -> Result<()> {
         self.guard(context, WamiAction::IamUpdateUser, "user", user_name)
             .await?;
-        self.write_store().tag_user(user_name, tags).await
+        self.write_store().await.tag_user(user_name, tags).await
     }
 
     /// List tags for a user
     pub async fn list_user_tags(&self, context: &WamiContext, user_name: &str) -> Result<Vec<Tag>> {
         self.guard(context, WamiAction::IamReadUser, "user", user_name)
             .await?;
-        self.read_store().list_user_tags(user_name).await
+        self.read_store().await.list_user_tags(user_name).await
     }
 
     /// Untag a user
@@ -202,7 +204,10 @@ impl<S: UserStore> UserService<S> {
     ) -> Result<()> {
         self.guard(context, WamiAction::IamUpdateUser, "user", user_name)
             .await?;
-        self.write_store().untag_user(user_name, tag_keys).await
+        self.write_store()
+            .await
+            .untag_user(user_name, tag_keys)
+            .await
     }
 }
 

--- a/crates/wami/src/service/mod.rs
+++ b/crates/wami/src/service/mod.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::await_holding_lock)]
 #![allow(clippy::result_large_err)]
 #![allow(clippy::unnecessary_map_or)]
 //! Service Layer

--- a/crates/wami/src/service/policies/attachment.rs
+++ b/crates/wami/src/service/policies/attachment.rs
@@ -696,6 +696,146 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_list_and_detach_group_policy() {
+        let store = Arc::new(RwLock::new(InMemoryWamiStore::new()));
+        let service = AttachmentService::new(store.clone());
+        let context = create_test_context().await;
+
+        let group = build_group("developers".to_string(), Some("/".to_string()), &context).unwrap();
+        store.write().await.create_group(group).await.unwrap();
+
+        let policy = build_policy(
+            "TestPolicy".to_string(),
+            r#"{"Version":"2012-10-17","Statement":[]}"#.to_string(),
+            None,
+            None,
+            None,
+            &context,
+        )
+        .unwrap();
+        let created_policy = store.write().await.create_policy(policy).await.unwrap();
+
+        service
+            .attach_group_policy(
+                &context,
+                AttachGroupPolicyRequest {
+                    group_name: "developers".to_string(),
+                    policy_arn: created_policy.arn.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let listed = service
+            .list_attached_group_policies(
+                &context,
+                ListAttachedGroupPoliciesRequest {
+                    group_name: "developers".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(listed.attached_policies.len(), 1);
+        assert_eq!(listed.attached_policies[0].policy_arn, created_policy.arn);
+
+        service
+            .detach_group_policy(
+                &context,
+                DetachGroupPolicyRequest {
+                    group_name: "developers".to_string(),
+                    policy_arn: created_policy.arn.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let after = service
+            .list_attached_group_policies(
+                &context,
+                ListAttachedGroupPoliciesRequest {
+                    group_name: "developers".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(after.attached_policies.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_list_and_detach_role_policy() {
+        let store = Arc::new(RwLock::new(InMemoryWamiStore::new()));
+        let service = AttachmentService::new(store.clone());
+        let context = create_test_context().await;
+
+        let role = build_role(
+            "AdminRole".to_string(),
+            r#"{"Version":"2012-10-17","Statement":[]}"#.to_string(),
+            Some("/".to_string()),
+            None,
+            None,
+            &context,
+        )
+        .unwrap();
+        store.write().await.create_role(role).await.unwrap();
+
+        let policy = build_policy(
+            "TestPolicy".to_string(),
+            r#"{"Version":"2012-10-17","Statement":[]}"#.to_string(),
+            None,
+            None,
+            None,
+            &context,
+        )
+        .unwrap();
+        let created_policy = store.write().await.create_policy(policy).await.unwrap();
+
+        service
+            .attach_role_policy(
+                &context,
+                AttachRolePolicyRequest {
+                    role_name: "AdminRole".to_string(),
+                    policy_arn: created_policy.arn.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let listed = service
+            .list_attached_role_policies(
+                &context,
+                ListAttachedRolePoliciesRequest {
+                    role_name: "AdminRole".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(listed.attached_policies.len(), 1);
+        assert_eq!(listed.attached_policies[0].policy_arn, created_policy.arn);
+
+        service
+            .detach_role_policy(
+                &context,
+                DetachRolePolicyRequest {
+                    role_name: "AdminRole".to_string(),
+                    policy_arn: created_policy.arn.clone(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let after = service
+            .list_attached_role_policies(
+                &context,
+                ListAttachedRolePoliciesRequest {
+                    role_name: "AdminRole".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(after.attached_policies.is_empty());
+    }
+
+    #[tokio::test]
     async fn test_attach_policy_user_not_found() {
         let store = Arc::new(RwLock::new(InMemoryWamiStore::new()));
         let service = AttachmentService::new(store.clone());

--- a/crates/wami/src/service/policies/attachment.rs
+++ b/crates/wami/src/service/policies/attachment.rs
@@ -5,7 +5,8 @@
 use crate::service::auth::authorizer::{iam_resource_arn, Authorizer};
 use crate::store::traits::{GroupStore, PolicyStore, RoleStore, UserStore};
 use crate::wami::policies::attachment::*;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::{AmiError, Result};
@@ -73,7 +74,7 @@ where
         )
         .await?;
 
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
 
         // Verify user exists
         store
@@ -130,7 +131,7 @@ where
         )
         .await?;
 
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
 
         // Verify user exists
         store
@@ -174,7 +175,7 @@ where
         )
         .await?;
 
-        let store = self.read_store();
+        let store = self.read_store().await;
 
         // Verify user exists
         store
@@ -219,7 +220,7 @@ where
         )
         .await?;
 
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
 
         // Verify group exists
         store
@@ -276,7 +277,7 @@ where
         )
         .await?;
 
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
 
         // Verify group exists
         store
@@ -320,7 +321,7 @@ where
         )
         .await?;
 
-        let store = self.read_store();
+        let store = self.read_store().await;
 
         // Verify group exists
         store
@@ -365,7 +366,7 @@ where
         )
         .await?;
 
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
 
         // Verify role exists
         store
@@ -422,7 +423,7 @@ where
         )
         .await?;
 
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
 
         // Verify role exists
         store
@@ -466,7 +467,7 @@ where
         )
         .await?;
 
-        let store = self.read_store();
+        let store = self.read_store().await;
 
         // Verify role exists
         store
@@ -534,7 +535,7 @@ mod tests {
 
         // Create user and policy
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
-        let _created_user = store.write().unwrap().create_user(user).await.unwrap();
+        let _created_user = store.write().await.create_user(user).await.unwrap();
 
         let policy = build_policy(
             "TestPolicy".to_string(),
@@ -545,7 +546,7 @@ mod tests {
             &context,
         )
         .unwrap();
-        let created_policy = store.write().unwrap().create_policy(policy).await.unwrap();
+        let created_policy = store.write().await.create_policy(policy).await.unwrap();
 
         // Attach policy to user
         let request = AttachUserPolicyRequest {
@@ -578,7 +579,7 @@ mod tests {
 
         // Create user and policy
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
-        let _created_user = store.write().unwrap().create_user(user).await.unwrap();
+        let _created_user = store.write().await.create_user(user).await.unwrap();
 
         let policy = build_policy(
             "TestPolicy".to_string(),
@@ -589,7 +590,7 @@ mod tests {
             &context,
         )
         .unwrap();
-        let created_policy = store.write().unwrap().create_policy(policy).await.unwrap();
+        let created_policy = store.write().await.create_policy(policy).await.unwrap();
 
         // Attach policy
         let attach_request = AttachUserPolicyRequest {
@@ -631,7 +632,7 @@ mod tests {
 
         // Create group and policy
         let group = build_group("developers".to_string(), Some("/".to_string()), &context).unwrap();
-        let _created_group = store.write().unwrap().create_group(group).await.unwrap();
+        let _created_group = store.write().await.create_group(group).await.unwrap();
 
         let policy = build_policy(
             "TestPolicy".to_string(),
@@ -642,7 +643,7 @@ mod tests {
             &context,
         )
         .unwrap();
-        let created_policy = store.write().unwrap().create_policy(policy).await.unwrap();
+        let created_policy = store.write().await.create_policy(policy).await.unwrap();
 
         // Attach policy to group
         let request = AttachGroupPolicyRequest {
@@ -672,7 +673,7 @@ mod tests {
             &context,
         )
         .unwrap();
-        let _created_role = store.write().unwrap().create_role(role).await.unwrap();
+        let _created_role = store.write().await.create_role(role).await.unwrap();
 
         let policy = build_policy(
             "TestPolicy".to_string(),
@@ -683,7 +684,7 @@ mod tests {
             &context,
         )
         .unwrap();
-        let created_policy = store.write().unwrap().create_policy(policy).await.unwrap();
+        let created_policy = store.write().await.create_policy(policy).await.unwrap();
 
         // Attach policy to role
         let request = AttachRolePolicyRequest {
@@ -709,7 +710,7 @@ mod tests {
             &context,
         )
         .unwrap();
-        let created_policy = store.write().unwrap().create_policy(policy).await.unwrap();
+        let created_policy = store.write().await.create_policy(policy).await.unwrap();
 
         let request = AttachUserPolicyRequest {
             user_name: "nonexistent".to_string(),
@@ -730,7 +731,7 @@ mod tests {
         let context = create_test_context().await;
 
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
-        let _created_user = store.write().unwrap().create_user(user).await.unwrap();
+        let _created_user = store.write().await.create_user(user).await.unwrap();
 
         let request = AttachUserPolicyRequest {
             user_name: "alice".to_string(),

--- a/crates/wami/src/service/policies/evaluation.rs
+++ b/crates/wami/src/service/policies/evaluation.rs
@@ -688,7 +688,9 @@ impl<S: EvaluationServiceStore> EvaluationService<S> {
 mod tests {
     use super::*;
     use crate::store::memory::InMemoryWamiStore;
+    use crate::wami::identity::role::builder::build_role;
     use crate::wami::identity::user::builder::build_user;
+    use crate::wami::policies::policy::builder::build_policy;
     use wami_core::arn::{TenantPath, WamiArn};
     use wami_core::context::WamiContext;
 
@@ -861,6 +863,90 @@ mod tests {
 
         assert_eq!(response.evaluation_results.len(), 1);
         assert_eq!(response.evaluation_results[0].eval_decision, "allowed");
+    }
+
+    #[tokio::test]
+    async fn test_simulate_principal_policy_role_with_boundary() {
+        // Drives the `role` arms of both fetch_principal_policies and
+        // fetch_permissions_boundary, and the boundary lookup that follows.
+        let service = setup_service();
+        let context = test_context();
+
+        let boundary = build_policy(
+            "Boundary".to_string(),
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":"ec2:DescribeInstances","Resource":"*"}]}"#
+                .to_string(),
+            None,
+            None,
+            None,
+            &context,
+        )
+        .unwrap();
+        let boundary_arn = boundary.arn.clone();
+        service
+            .store
+            .write()
+            .await
+            .create_policy(boundary)
+            .await
+            .unwrap();
+
+        let mut role = build_role(
+            "AppRole".to_string(),
+            r#"{"Version":"2012-10-17","Statement":[]}"#.to_string(),
+            Some("/".to_string()),
+            None,
+            None,
+            &context,
+        )
+        .unwrap();
+        role.permissions_boundary = Some(boundary_arn);
+        service.store.write().await.create_role(role).await.unwrap();
+
+        let identity = r#"{
+            "Version": "2012-10-17",
+            "Statement": [
+                {"Effect": "Allow", "Action": "ec2:DescribeInstances", "Resource": "*"},
+                {"Effect": "Allow", "Action": "s3:GetObject", "Resource": "*"}
+            ]
+        }"#;
+
+        let response = service
+            .simulate_principal_policy(SimulatePrincipalPolicyRequest {
+                policy_source_arn: "arn:aws:iam::123456789012:role/AppRole".to_string(),
+                action_names: vec![
+                    "ec2:DescribeInstances".to_string(),
+                    "s3:GetObject".to_string(),
+                ],
+                resource_arns: None,
+                policy_input_list: Some(vec![identity.to_string()]),
+                context_entries: None,
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(response.evaluation_results.len(), 2);
+        // Allowed by both the identity policy and the boundary.
+        assert_eq!(response.evaluation_results[0].eval_decision, "allowed");
+        // Allowed by the identity policy but outside the boundary.
+        assert_ne!(response.evaluation_results[1].eval_decision, "allowed");
+    }
+
+    #[tokio::test]
+    async fn test_simulate_principal_policy_unknown_role() {
+        let service = setup_service();
+
+        let result = service
+            .simulate_principal_policy(SimulatePrincipalPolicyRequest {
+                policy_source_arn: "arn:aws:iam::123456789012:role/Missing".to_string(),
+                action_names: vec!["ec2:DescribeInstances".to_string()],
+                resource_arns: None,
+                policy_input_list: None,
+                context_entries: None,
+            })
+            .await;
+
+        assert!(matches!(result, Err(AmiError::ResourceNotFound { .. })));
     }
 
     #[tokio::test]

--- a/crates/wami/src/service/policies/evaluation.rs
+++ b/crates/wami/src/service/policies/evaluation.rs
@@ -9,7 +9,8 @@ use crate::wami::policies::evaluation::{
     SimulatePrincipalPolicyRequest, StatementMatch,
 };
 use serde_json::Value;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_condition::evaluator::parse_condition_block;
 use wami_condition::{evaluate_condition_block, ConditionContext, ConditionValue};
 use wami_core::error::{AmiError, Result};
@@ -237,7 +238,7 @@ impl<S: EvaluationServiceStore> EvaluationService<S> {
                 let _user = self
                     .store
                     .read()
-                    .unwrap()
+                    .await
                     .get_user(principal_name)
                     .await?
                     .ok_or_else(|| AmiError::ResourceNotFound {
@@ -256,7 +257,7 @@ impl<S: EvaluationServiceStore> EvaluationService<S> {
                 let _role = self
                     .store
                     .read()
-                    .unwrap()
+                    .await
                     .get_role(principal_name)
                     .await?
                     .ok_or_else(|| AmiError::ResourceNotFound {
@@ -286,7 +287,7 @@ impl<S: EvaluationServiceStore> EvaluationService<S> {
                 let user = self
                     .store
                     .read()
-                    .unwrap()
+                    .await
                     .get_user(principal_name)
                     .await?
                     .ok_or_else(|| AmiError::ResourceNotFound {
@@ -298,7 +299,7 @@ impl<S: EvaluationServiceStore> EvaluationService<S> {
                 let role = self
                     .store
                     .read()
-                    .unwrap()
+                    .await
                     .get_role(principal_name)
                     .await?
                     .ok_or_else(|| AmiError::ResourceNotFound {
@@ -315,7 +316,7 @@ impl<S: EvaluationServiceStore> EvaluationService<S> {
 
         // Fetch the boundary policy if it exists
         if let Some(arn) = boundary_arn {
-            let policy = self.store.read().unwrap().get_policy(&arn).await?;
+            let policy = self.store.read().await.get_policy(&arn).await?;
             Ok(policy)
         } else {
             Ok(None)
@@ -832,13 +833,7 @@ mod tests {
         // Create a user
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
 
-        service
-            .store
-            .write()
-            .unwrap()
-            .create_user(user)
-            .await
-            .unwrap();
+        service.store.write().await.create_user(user).await.unwrap();
 
         // Create a policy document for testing
         let policy_doc = r#"{
@@ -1739,7 +1734,7 @@ mod tests {
         // Create a user first so the principal exists
         let store = Arc::new(RwLock::new(InMemoryWamiStore::default()));
         let user = build_user("alice".to_string(), None, &test_context()).unwrap();
-        store.write().unwrap().create_user(user).await.unwrap();
+        store.write().await.create_user(user).await.unwrap();
 
         let service = EvaluationService::new(store, "123456789012".to_string());
         let request = SimulatePrincipalPolicyRequest {

--- a/crates/wami/src/service/policies/inline.rs
+++ b/crates/wami/src/service/policies/inline.rs
@@ -5,7 +5,8 @@
 use crate::service::auth::authorizer::{iam_resource_arn, Authorizer};
 use crate::store::traits::{GroupStore, RoleStore, UserStore};
 use crate::wami::policies::inline::*;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::{AmiError, Result};
@@ -73,7 +74,7 @@ where
         )
         .await?;
 
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
 
         // Verify user exists
         store
@@ -121,7 +122,7 @@ where
         )
         .await?;
 
-        let store = self.read_store();
+        let store = self.read_store().await;
 
         // Verify user exists
         store
@@ -163,7 +164,7 @@ where
         )
         .await?;
 
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
 
         // Verify user exists
         store
@@ -200,7 +201,7 @@ where
         )
         .await?;
 
-        let store = self.read_store();
+        let store = self.read_store().await;
 
         // Verify user exists
         store
@@ -232,7 +233,7 @@ where
         )
         .await?;
 
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
 
         // Verify group exists
         store
@@ -280,7 +281,7 @@ where
         )
         .await?;
 
-        let store = self.read_store();
+        let store = self.read_store().await;
 
         // Verify group exists
         store
@@ -322,7 +323,7 @@ where
         )
         .await?;
 
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
 
         // Verify group exists
         store
@@ -359,7 +360,7 @@ where
         )
         .await?;
 
-        let store = self.read_store();
+        let store = self.read_store().await;
 
         // Verify group exists
         store
@@ -391,7 +392,7 @@ where
         )
         .await?;
 
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
 
         // Verify role exists
         store
@@ -439,7 +440,7 @@ where
         )
         .await?;
 
-        let store = self.read_store();
+        let store = self.read_store().await;
 
         // Verify role exists
         store
@@ -481,7 +482,7 @@ where
         )
         .await?;
 
-        let mut store = self.write_store();
+        let mut store = self.write_store().await;
 
         // Verify role exists
         store
@@ -518,7 +519,7 @@ where
         )
         .await?;
 
-        let store = self.read_store();
+        let store = self.read_store().await;
 
         // Verify role exists
         store
@@ -571,7 +572,7 @@ mod tests {
         let context = create_test_context().await;
 
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
-        let _created_user = store.write().unwrap().create_user(user).await.unwrap();
+        let _created_user = store.write().await.create_user(user).await.unwrap();
 
         let request = PutUserPolicyRequest {
             user_name: "alice".to_string(),
@@ -589,7 +590,7 @@ mod tests {
         let context = create_test_context().await;
 
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
-        let _created_user = store.write().unwrap().create_user(user).await.unwrap();
+        let _created_user = store.write().await.create_user(user).await.unwrap();
 
         let put_request = PutUserPolicyRequest {
             user_name: "alice".to_string(),
@@ -620,7 +621,7 @@ mod tests {
         let context = create_test_context().await;
 
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
-        let _created_user = store.write().unwrap().create_user(user).await.unwrap();
+        let _created_user = store.write().await.create_user(user).await.unwrap();
 
         let put_request = PutUserPolicyRequest {
             user_name: "alice".to_string(),
@@ -650,7 +651,7 @@ mod tests {
         let context = create_test_context().await;
 
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
-        let _created_user = store.write().unwrap().create_user(user).await.unwrap();
+        let _created_user = store.write().await.create_user(user).await.unwrap();
 
         let put_request1 = PutUserPolicyRequest {
             user_name: "alice".to_string(),
@@ -689,7 +690,7 @@ mod tests {
         let context = create_test_context().await;
 
         let group = build_group("developers".to_string(), Some("/".to_string()), &context).unwrap();
-        let _created_group = store.write().unwrap().create_group(group).await.unwrap();
+        let _created_group = store.write().await.create_group(group).await.unwrap();
 
         let request = PutGroupPolicyRequest {
             group_name: "developers".to_string(),
@@ -715,7 +716,7 @@ mod tests {
             &context,
         )
         .unwrap();
-        let _created_role = store.write().unwrap().create_role(role).await.unwrap();
+        let _created_role = store.write().await.create_role(role).await.unwrap();
 
         let request = PutRolePolicyRequest {
             role_name: "AdminRole".to_string(),
@@ -733,7 +734,7 @@ mod tests {
         let context = create_test_context().await;
 
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
-        let _created_user = store.write().unwrap().create_user(user).await.unwrap();
+        let _created_user = store.write().await.create_user(user).await.unwrap();
 
         let request = PutUserPolicyRequest {
             user_name: "alice".to_string(),
@@ -788,7 +789,7 @@ mod tests {
         let context = create_test_context().await;
 
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
-        let _created_user = store.write().unwrap().create_user(user).await.unwrap();
+        let _created_user = store.write().await.create_user(user).await.unwrap();
 
         let request = GetUserPolicyRequest {
             user_name: "alice".to_string(),
@@ -922,7 +923,7 @@ mod tests {
 
         // Create user so the store operation can succeed
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
-        store.write().unwrap().create_user(user).await.unwrap();
+        store.write().await.create_user(user).await.unwrap();
 
         let request = PutUserPolicyRequest {
             user_name: "alice".to_string(),

--- a/crates/wami/src/service/policies/inline.rs
+++ b/crates/wami/src/service/policies/inline.rs
@@ -728,6 +728,150 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_group_policy_get_list_delete() {
+        let store = Arc::new(RwLock::new(InMemoryWamiStore::new()));
+        let service = InlinePolicyService::new(store.clone());
+        let context = create_test_context().await;
+
+        let group = build_group("developers".to_string(), Some("/".to_string()), &context).unwrap();
+        store.write().await.create_group(group).await.unwrap();
+
+        let document = r#"{"Version":"2012-10-17","Statement":[]}"#;
+        service
+            .put_group_policy(
+                &context,
+                PutGroupPolicyRequest {
+                    group_name: "developers".to_string(),
+                    policy_name: "MyInlinePolicy".to_string(),
+                    policy_document: document.to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let got = service
+            .get_group_policy(
+                &context,
+                GetGroupPolicyRequest {
+                    group_name: "developers".to_string(),
+                    policy_name: "MyInlinePolicy".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(got.policy_document, document);
+
+        let listed = service
+            .list_group_policies(
+                &context,
+                ListGroupPoliciesRequest {
+                    group_name: "developers".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(listed.policy_names, vec!["MyInlinePolicy".to_string()]);
+
+        service
+            .delete_group_policy(
+                &context,
+                DeleteGroupPolicyRequest {
+                    group_name: "developers".to_string(),
+                    policy_name: "MyInlinePolicy".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let after = service
+            .list_group_policies(
+                &context,
+                ListGroupPoliciesRequest {
+                    group_name: "developers".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(after.policy_names.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_role_policy_get_list_delete() {
+        let store = Arc::new(RwLock::new(InMemoryWamiStore::new()));
+        let service = InlinePolicyService::new(store.clone());
+        let context = create_test_context().await;
+
+        let role = build_role(
+            "AdminRole".to_string(),
+            r#"{"Version":"2012-10-17","Statement":[]}"#.to_string(),
+            Some("/".to_string()),
+            None,
+            None,
+            &context,
+        )
+        .unwrap();
+        store.write().await.create_role(role).await.unwrap();
+
+        let document = r#"{"Version":"2012-10-17","Statement":[]}"#;
+        service
+            .put_role_policy(
+                &context,
+                PutRolePolicyRequest {
+                    role_name: "AdminRole".to_string(),
+                    policy_name: "MyInlinePolicy".to_string(),
+                    policy_document: document.to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let got = service
+            .get_role_policy(
+                &context,
+                GetRolePolicyRequest {
+                    role_name: "AdminRole".to_string(),
+                    policy_name: "MyInlinePolicy".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(got.policy_document, document);
+
+        let listed = service
+            .list_role_policies(
+                &context,
+                ListRolePoliciesRequest {
+                    role_name: "AdminRole".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(listed.policy_names, vec!["MyInlinePolicy".to_string()]);
+
+        service
+            .delete_role_policy(
+                &context,
+                DeleteRolePolicyRequest {
+                    role_name: "AdminRole".to_string(),
+                    policy_name: "MyInlinePolicy".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let after = service
+            .list_role_policies(
+                &context,
+                ListRolePoliciesRequest {
+                    role_name: "AdminRole".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+        assert!(after.policy_names.is_empty());
+    }
+
+    #[tokio::test]
     async fn test_invalid_json_policy() {
         let store = Arc::new(RwLock::new(InMemoryWamiStore::new()));
         let service = InlinePolicyService::new(store.clone());

--- a/crates/wami/src/service/policies/permissions_boundary.rs
+++ b/crates/wami/src/service/policies/permissions_boundary.rs
@@ -7,7 +7,8 @@ use crate::store::traits::{PolicyStore, RoleStore, UserStore};
 use crate::wami::policies::permissions_boundary::{
     operations, DeletePermissionsBoundaryRequest, PrincipalType, PutPermissionsBoundaryRequest,
 };
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::{AmiError, Result};
@@ -111,7 +112,7 @@ where
         )?;
 
         // Get the boundary policy to validate it exists and is suitable
-        let store = self.read_store();
+        let store = self.read_store().await;
         let policy = store
             .get_policy(&request.permissions_boundary)
             .await?
@@ -126,7 +127,7 @@ where
         // Update the principal with the boundary
         match request.principal_type {
             PrincipalType::User => {
-                let mut store = self.write_store();
+                let mut store = self.write_store().await;
                 let mut user = store
                     .get_user(&request.principal_name)
                     .await?
@@ -139,7 +140,7 @@ where
                 store.update_user(user).await?;
             }
             PrincipalType::Role => {
-                let mut store = self.write_store();
+                let mut store = self.write_store().await;
                 let mut role = store
                     .get_role(&request.principal_name)
                     .await?
@@ -189,7 +190,7 @@ where
 
         match request.principal_type {
             PrincipalType::User => {
-                let mut store = self.write_store();
+                let mut store = self.write_store().await;
                 let mut user = store
                     .get_user(&request.principal_name)
                     .await?
@@ -202,7 +203,7 @@ where
                 store.update_user(user).await?;
             }
             PrincipalType::Role => {
-                let mut store = self.write_store();
+                let mut store = self.write_store().await;
                 let mut role = store
                     .get_role(&request.principal_name)
                     .await?
@@ -253,7 +254,7 @@ mod tests {
         // Create a user
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
         {
-            let mut s = store.write().unwrap();
+            let mut s = store.write().await;
             s.create_user(user).await.unwrap();
         }
 
@@ -276,7 +277,7 @@ mod tests {
         )
         .unwrap();
         {
-            let mut s = store.write().unwrap();
+            let mut s = store.write().await;
             s.create_policy(policy.clone()).await.unwrap();
         }
 
@@ -294,7 +295,7 @@ mod tests {
         match result {
             Ok(_) => {
                 // Verify boundary was set
-                let s = store.read().unwrap();
+                let s = store.read().await;
                 let updated_user = s.get_user("alice").await.unwrap().unwrap();
                 assert_eq!(
                     updated_user.permissions_boundary,
@@ -325,7 +326,7 @@ mod tests {
         )
         .unwrap();
         {
-            let mut s = store.write().unwrap();
+            let mut s = store.write().await;
             s.create_role(role).await.unwrap();
         }
 
@@ -348,7 +349,7 @@ mod tests {
         )
         .unwrap();
         {
-            let mut s = store.write().unwrap();
+            let mut s = store.write().await;
             s.create_policy(policy.clone()).await.unwrap();
         }
 
@@ -365,7 +366,7 @@ mod tests {
             .unwrap();
 
         // Verify boundary was set
-        let s = store.read().unwrap();
+        let s = store.read().await;
         let updated_role = s.get_role("test-role").await.unwrap().unwrap();
         assert_eq!(updated_role.permissions_boundary, Some(policy.arn.clone()));
     }
@@ -389,7 +390,7 @@ mod tests {
         .unwrap();
         role.permissions_boundary = Some("arn:aws:iam::123456789012:policy/boundary".to_string());
         {
-            let mut s = store.write().unwrap();
+            let mut s = store.write().await;
             s.create_role(role).await.unwrap();
         }
 
@@ -405,7 +406,7 @@ mod tests {
             .unwrap();
 
         // Verify boundary was removed
-        let s = store.read().unwrap();
+        let s = store.read().await;
         let updated_role = s.get_role("test-role").await.unwrap().unwrap();
         assert_eq!(updated_role.permissions_boundary, None);
     }
@@ -436,7 +437,7 @@ mod tests {
         // Create a user
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
         {
-            let mut s = store.write().unwrap();
+            let mut s = store.write().await;
             s.create_user(user).await.unwrap();
         }
 
@@ -475,7 +476,7 @@ mod tests {
         )
         .unwrap();
         {
-            let mut s = store.write().unwrap();
+            let mut s = store.write().await;
             s.create_policy(policy.clone()).await.unwrap();
         }
 

--- a/crates/wami/src/service/policies/permissions_boundary.rs
+++ b/crates/wami/src/service/policies/permissions_boundary.rs
@@ -412,6 +412,55 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_delete_boundary_from_user() {
+        let store = Arc::new(RwLock::new(InMemoryWamiStore::default()));
+        let context = test_context();
+        let service = PermissionsBoundaryService::new(store.clone(), "123456789012".to_string());
+
+        let mut user =
+            build_user("test-user".to_string(), Some("/".to_string()), &context).unwrap();
+        user.permissions_boundary = Some("arn:aws:iam::123456789012:policy/boundary".to_string());
+        {
+            let mut s = store.write().await;
+            s.create_user(user).await.unwrap();
+        }
+
+        service
+            .delete_permissions_boundary(
+                &context,
+                DeletePermissionsBoundaryRequest {
+                    principal_type: PrincipalType::User,
+                    principal_name: "test-user".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+
+        let s = store.read().await;
+        let updated_user = s.get_user("test-user").await.unwrap().unwrap();
+        assert_eq!(updated_user.permissions_boundary, None);
+    }
+
+    #[tokio::test]
+    async fn test_delete_boundary_from_unknown_user() {
+        let store = Arc::new(RwLock::new(InMemoryWamiStore::default()));
+        let context = test_context();
+        let service = PermissionsBoundaryService::new(store.clone(), "123456789012".to_string());
+
+        let result = service
+            .delete_permissions_boundary(
+                &context,
+                DeletePermissionsBoundaryRequest {
+                    principal_type: PrincipalType::User,
+                    principal_name: "missing".to_string(),
+                },
+            )
+            .await;
+
+        assert!(matches!(result, Err(AmiError::ResourceNotFound { .. })));
+    }
+
+    #[tokio::test]
     async fn test_put_boundary_invalid_arn() {
         let store = Arc::new(RwLock::new(InMemoryWamiStore::default()));
         let context = test_context();

--- a/crates/wami/src/service/policies/policy.rs
+++ b/crates/wami/src/service/policies/policy.rs
@@ -8,7 +8,8 @@ use crate::wami::policies::policy::{
     builder as policy_builder, CreatePolicyRequest, ListPoliciesRequest, Policy,
     UpdatePolicyRequest,
 };
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::Result;
@@ -81,7 +82,7 @@ impl<S: PolicyStore> PolicyService<S> {
         )?;
 
         // Store it
-        self.write_store().create_policy(policy).await
+        self.write_store().await.create_policy(policy).await
     }
 
     /// Get a policy by ARN
@@ -92,7 +93,7 @@ impl<S: PolicyStore> PolicyService<S> {
     ) -> Result<Option<Policy>> {
         self.guard(context, WamiAction::IamReadPolicy, "policy", policy_arn)
             .await?;
-        self.read_store().get_policy(policy_arn).await
+        self.read_store().await.get_policy(policy_arn).await
     }
 
     /// Update a policy
@@ -113,7 +114,7 @@ impl<S: PolicyStore> PolicyService<S> {
         let policy = self
             .store
             .read()
-            .unwrap()
+            .await
             .get_policy(&request.policy_arn)
             .await?
             .ok_or_else(|| crate::error::AmiError::ResourceNotFound {
@@ -125,18 +126,14 @@ impl<S: PolicyStore> PolicyService<S> {
             policy_builder::update_policy(policy, request.description, request.default_version_id);
 
         // Store updated policy
-        self.store
-            .write()
-            .unwrap()
-            .update_policy(updated_policy)
-            .await
+        self.store.write().await.update_policy(updated_policy).await
     }
 
     /// Delete a policy
     pub async fn delete_policy(&self, context: &WamiContext, policy_arn: &str) -> Result<()> {
         self.guard(context, WamiAction::IamDeletePolicy, "policy", policy_arn)
             .await?;
-        self.write_store().delete_policy(policy_arn).await
+        self.write_store().await.delete_policy(policy_arn).await
     }
 
     /// List policies with optional filtering
@@ -149,7 +146,7 @@ impl<S: PolicyStore> PolicyService<S> {
             .await?;
         self.store
             .read()
-            .unwrap()
+            .await
             .list_policies(request.scope.as_deref(), request.pagination.as_ref())
             .await
     }

--- a/crates/wami/src/service/reports/credential_report.rs
+++ b/crates/wami/src/service/reports/credential_report.rs
@@ -12,7 +12,8 @@ use crate::wami::reports::credential_report::{
     GenerateCredentialReportResponse, GetAccountSummaryRequest, GetAccountSummaryResponse,
     GetCredentialReportRequest, GetCredentialReportResponse,
 };
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::error::{AmiError, Result};
 
 pub trait CredentialReportServiceStore:
@@ -84,12 +85,7 @@ where
         _request: GenerateCredentialReportRequest,
     ) -> Result<GenerateCredentialReportResponse> {
         // Fetch all users
-        let (users, _, _) = self
-            .store
-            .read()
-            .expect("store read lock poisoned")
-            .list_users(None, None)
-            .await?;
+        let (users, _, _) = self.store.read().await.list_users(None, None).await?;
 
         // Generate CSV content
         let mut csv_content = String::from(
@@ -103,14 +99,14 @@ where
             let mfa_devices = self
                 .store
                 .read()
-                .unwrap()
+                .await
                 .list_mfa_devices(&user.user_name)
                 .await?;
 
             let access_keys = self
                 .store
                 .read()
-                .unwrap()
+                .await
                 .list_access_keys(&user.user_name, None)
                 .await?
                 .0;
@@ -118,7 +114,7 @@ where
             let has_login_profile = self
                 .store
                 .read()
-                .unwrap()
+                .await
                 .get_login_profile(&user.user_name)
                 .await?
                 .is_some();
@@ -162,7 +158,7 @@ where
 
         self.store
             .write()
-            .unwrap()
+            .await
             .store_credential_report(report)
             .await?;
 
@@ -180,7 +176,7 @@ where
         let report = self
             .store
             .read()
-            .unwrap()
+            .await
             .get_credential_report()
             .await?
             .ok_or_else(|| AmiError::ResourceNotFound {
@@ -205,7 +201,7 @@ where
         &self,
         _request: GetAccountSummaryRequest,
     ) -> Result<GetAccountSummaryResponse> {
-        let store_read = self.store.read().expect("store read lock poisoned");
+        let store_read = self.store.read().await;
 
         // Count users
         let (users, _, _) = store_read.list_users(None, None).await?;
@@ -294,13 +290,7 @@ mod tests {
         // Create some test users
         for i in 0..3 {
             let user = build_user(format!("user{}", i), Some("/".to_string()), &context).unwrap();
-            service
-                .store
-                .write()
-                .unwrap()
-                .create_user(user)
-                .await
-                .unwrap();
+            service.store.write().await.create_user(user).await.unwrap();
         }
 
         let request = GenerateCredentialReportRequest {};
@@ -317,13 +307,7 @@ mod tests {
 
         // Create a user
         let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
-        service
-            .store
-            .write()
-            .unwrap()
-            .create_user(user)
-            .await
-            .unwrap();
+        service.store.write().await.create_user(user).await.unwrap();
 
         // Generate report
         let gen_request = GenerateCredentialReportRequest {};
@@ -373,13 +357,7 @@ mod tests {
         // Create users
         for i in 0..5 {
             let user = build_user(format!("user{}", i), Some("/".to_string()), &context).unwrap();
-            service
-                .store
-                .write()
-                .unwrap()
-                .create_user(user)
-                .await
-                .unwrap();
+            service.store.write().await.create_user(user).await.unwrap();
         }
 
         let request = GetAccountSummaryRequest {};

--- a/crates/wami/src/service/sso_admin/account_assignment.rs
+++ b/crates/wami/src/service/sso_admin/account_assignment.rs
@@ -5,7 +5,8 @@
 use crate::provider::{AwsProvider, CloudProvider};
 use crate::store::traits::AccountAssignmentStore;
 use crate::wami::sso_admin::account_assignment::AccountAssignment;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::error::Result;
 
 /// Service for managing account assignments
@@ -43,7 +44,7 @@ impl<S: AccountAssignmentStore> AccountAssignmentService<S> {
     ) -> Result<AccountAssignment> {
         self.store
             .write()
-            .unwrap()
+            .await
             .create_account_assignment(assignment)
             .await
     }
@@ -55,7 +56,7 @@ impl<S: AccountAssignmentStore> AccountAssignmentService<S> {
     ) -> Result<Option<AccountAssignment>> {
         self.store
             .read()
-            .unwrap()
+            .await
             .get_account_assignment(assignment_id)
             .await
     }
@@ -64,7 +65,7 @@ impl<S: AccountAssignmentStore> AccountAssignmentService<S> {
     pub async fn delete_account_assignment(&self, assignment_id: &str) -> Result<()> {
         self.store
             .write()
-            .unwrap()
+            .await
             .delete_account_assignment(assignment_id)
             .await
     }
@@ -77,7 +78,7 @@ impl<S: AccountAssignmentStore> AccountAssignmentService<S> {
     ) -> Result<Vec<AccountAssignment>> {
         self.store
             .read()
-            .unwrap()
+            .await
             .list_account_assignments(account_id, permission_set_arn)
             .await
     }

--- a/crates/wami/src/service/sso_admin/application.rs
+++ b/crates/wami/src/service/sso_admin/application.rs
@@ -5,7 +5,8 @@
 use crate::provider::{AwsProvider, CloudProvider};
 use crate::store::traits::ApplicationStore;
 use crate::wami::sso_admin::application::Application;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::error::Result;
 
 /// Service for managing applications
@@ -40,7 +41,7 @@ impl<S: ApplicationStore> ApplicationService<S> {
     pub async fn create_application(&self, application: Application) -> Result<Application> {
         self.store
             .write()
-            .unwrap()
+            .await
             .create_application(application)
             .await
     }
@@ -49,7 +50,7 @@ impl<S: ApplicationStore> ApplicationService<S> {
     pub async fn get_application(&self, application_arn: &str) -> Result<Option<Application>> {
         self.store
             .read()
-            .unwrap()
+            .await
             .get_application(application_arn)
             .await
     }
@@ -58,7 +59,7 @@ impl<S: ApplicationStore> ApplicationService<S> {
     pub async fn list_applications(&self, instance_arn: &str) -> Result<Vec<Application>> {
         self.store
             .read()
-            .unwrap()
+            .await
             .list_applications(instance_arn)
             .await
     }

--- a/crates/wami/src/service/sso_admin/instance.rs
+++ b/crates/wami/src/service/sso_admin/instance.rs
@@ -5,7 +5,8 @@
 use crate::provider::{AwsProvider, CloudProvider};
 use crate::store::traits::SsoInstanceStore;
 use crate::wami::sso_admin::instance::SsoInstance;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::error::Result;
 
 /// Service for managing SSO instances
@@ -38,29 +39,17 @@ impl<S: SsoInstanceStore> InstanceService<S> {
 
     /// Create a new SSO instance
     pub async fn create_instance(&self, instance: SsoInstance) -> Result<SsoInstance> {
-        self.store
-            .write()
-            .expect("store write lock poisoned")
-            .create_instance(instance)
-            .await
+        self.store.write().await.create_instance(instance).await
     }
 
     /// Get an SSO instance by ARN
     pub async fn get_instance(&self, instance_arn: &str) -> Result<Option<SsoInstance>> {
-        self.store
-            .read()
-            .expect("store read lock poisoned")
-            .get_instance(instance_arn)
-            .await
+        self.store.read().await.get_instance(instance_arn).await
     }
 
     /// List all SSO instances
     pub async fn list_instances(&self) -> Result<Vec<SsoInstance>> {
-        self.store
-            .read()
-            .expect("store read lock poisoned")
-            .list_instances()
-            .await
+        self.store.read().await.list_instances().await
     }
 }
 

--- a/crates/wami/src/service/sso_admin/permission_set.rs
+++ b/crates/wami/src/service/sso_admin/permission_set.rs
@@ -5,7 +5,8 @@
 use crate::provider::{AwsProvider, CloudProvider};
 use crate::store::traits::PermissionSetStore;
 use crate::wami::sso_admin::permission_set::PermissionSet;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::error::Result;
 
 /// Service for managing permission sets
@@ -43,7 +44,7 @@ impl<S: PermissionSetStore> PermissionSetService<S> {
     ) -> Result<PermissionSet> {
         self.store
             .write()
-            .unwrap()
+            .await
             .create_permission_set(permission_set)
             .await
     }
@@ -55,7 +56,7 @@ impl<S: PermissionSetStore> PermissionSetService<S> {
     ) -> Result<Option<PermissionSet>> {
         self.store
             .read()
-            .unwrap()
+            .await
             .get_permission_set(permission_set_arn)
             .await
     }
@@ -67,7 +68,7 @@ impl<S: PermissionSetStore> PermissionSetService<S> {
     ) -> Result<PermissionSet> {
         self.store
             .write()
-            .unwrap()
+            .await
             .update_permission_set(permission_set)
             .await
     }
@@ -76,7 +77,7 @@ impl<S: PermissionSetStore> PermissionSetService<S> {
     pub async fn delete_permission_set(&self, permission_set_arn: &str) -> Result<()> {
         self.store
             .write()
-            .unwrap()
+            .await
             .delete_permission_set(permission_set_arn)
             .await
     }
@@ -85,7 +86,7 @@ impl<S: PermissionSetStore> PermissionSetService<S> {
     pub async fn list_permission_sets(&self, instance_arn: &str) -> Result<Vec<PermissionSet>> {
         self.store
             .read()
-            .unwrap()
+            .await
             .list_permission_sets(instance_arn)
             .await
     }

--- a/crates/wami/src/service/sso_admin/trusted_token_issuer.rs
+++ b/crates/wami/src/service/sso_admin/trusted_token_issuer.rs
@@ -5,7 +5,8 @@
 use crate::provider::{AwsProvider, CloudProvider};
 use crate::store::traits::TrustedTokenIssuerStore;
 use crate::wami::sso_admin::trusted_token_issuer::TrustedTokenIssuer;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::error::Result;
 
 /// Service for managing trusted token issuers
@@ -43,7 +44,7 @@ impl<S: TrustedTokenIssuerStore> TrustedTokenIssuerService<S> {
     ) -> Result<TrustedTokenIssuer> {
         self.store
             .write()
-            .unwrap()
+            .await
             .create_trusted_token_issuer(issuer)
             .await
     }
@@ -55,7 +56,7 @@ impl<S: TrustedTokenIssuerStore> TrustedTokenIssuerService<S> {
     ) -> Result<Option<TrustedTokenIssuer>> {
         self.store
             .read()
-            .unwrap()
+            .await
             .get_trusted_token_issuer(issuer_arn)
             .await
     }
@@ -64,7 +65,7 @@ impl<S: TrustedTokenIssuerStore> TrustedTokenIssuerService<S> {
     pub async fn delete_trusted_token_issuer(&self, issuer_arn: &str) -> Result<()> {
         self.store
             .write()
-            .unwrap()
+            .await
             .delete_trusted_token_issuer(issuer_arn)
             .await
     }
@@ -76,7 +77,7 @@ impl<S: TrustedTokenIssuerStore> TrustedTokenIssuerService<S> {
     ) -> Result<Vec<TrustedTokenIssuer>> {
         self.store
             .read()
-            .unwrap()
+            .await
             .list_trusted_token_issuers(instance_arn)
             .await
     }

--- a/crates/wami/src/service/sts/assume_role.rs
+++ b/crates/wami/src/service/sts/assume_role.rs
@@ -7,7 +7,8 @@ use crate::wami::sts::assume_role::{AssumeRoleRequest, AssumeRoleResponse, Assum
 use crate::wami::sts::session::SessionStatus;
 use crate::wami::sts::{Credentials, StsSession};
 use chrono::{Duration, Utc};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::arn::{Service, WamiArn};
 use wami_core::context::WamiContext;
 use wami_core::error::{AmiError, Result};
@@ -85,7 +86,7 @@ impl<S: AssumeRoleServiceStore> AssumeRoleService<S> {
         let role = if let Ok(wami_arn) = request.role_arn.parse::<crate::arn::WamiArn>() {
             if wami_arn.resource.resource_type == "role" {
                 // Search for role by matching wami_arn
-                let store_guard = self.read_store();
+                let store_guard = self.read_store().await;
                 let (roles, _, _) = store_guard.list_roles(None, None).await?;
                 roles
                     .into_iter()
@@ -103,7 +104,7 @@ impl<S: AssumeRoleServiceStore> AssumeRoleService<S> {
             let role_name = self.extract_role_name_from_arn(&request.role_arn)?;
             self.store
                 .read()
-                .unwrap()
+                .await
                 .get_role(&role_name)
                 .await?
                 .ok_or_else(|| AmiError::ResourceNotFound {
@@ -195,7 +196,7 @@ impl<S: AssumeRoleServiceStore> AssumeRoleService<S> {
             last_used: None,
         };
 
-        self.write_store().create_session(session).await?;
+        self.write_store().await.create_session(session).await?;
 
         Ok(AssumeRoleResponse {
             credentials,
@@ -279,13 +280,7 @@ mod tests {
 
         let role_arn = role.wami_arn.to_string();
 
-        service
-            .store
-            .write()
-            .unwrap()
-            .create_role(role)
-            .await
-            .unwrap();
+        service.store.write().await.create_role(role).await.unwrap();
 
         // Assume the role
         let request = AssumeRoleRequest {
@@ -347,13 +342,7 @@ mod tests {
 
         let role_arn = role.wami_arn.to_string();
 
-        service
-            .store
-            .write()
-            .unwrap()
-            .create_role(role)
-            .await
-            .unwrap();
+        service.store.write().await.create_role(role).await.unwrap();
 
         // Assume with external ID
         let request = AssumeRoleRequest {
@@ -395,13 +384,7 @@ mod tests {
 
         let role_arn = role.wami_arn.to_string();
 
-        service
-            .store
-            .write()
-            .unwrap()
-            .create_role(role)
-            .await
-            .unwrap();
+        service.store.write().await.create_role(role).await.unwrap();
 
         // Assume the role
         let request = AssumeRoleRequest {
@@ -421,7 +404,7 @@ mod tests {
         let sessions = service
             .store
             .read()
-            .unwrap()
+            .await
             .list_sessions(None)
             .await
             .unwrap();
@@ -469,13 +452,7 @@ mod tests {
         .unwrap();
 
         let role_arn = role.wami_arn.to_string();
-        service
-            .store
-            .write()
-            .unwrap()
-            .create_role(role)
-            .await
-            .unwrap();
+        service.store.write().await.create_role(role).await.unwrap();
 
         let km = KeyManager::generate();
         let request = AssumeRoleRequest {

--- a/crates/wami/src/service/sts/assume_role.rs
+++ b/crates/wami/src/service/sts/assume_role.rs
@@ -324,6 +324,64 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_assume_role_with_aws_format_arn() {
+        // An ARN that does not parse as a WAMI ARN takes the AWS fallback path,
+        // which looks the role up by the name pulled out of the ARN.
+        let service = setup_service();
+        let context = test_context();
+
+        let role = build_role(
+            "LegacyRole".to_string(),
+            r#"{"Version":"2012-10-17","Statement":[]}"#.to_string(),
+            Some("/".to_string()),
+            None,
+            None,
+            &context,
+        )
+        .unwrap();
+        service.store.write().await.create_role(role).await.unwrap();
+
+        let response = service
+            .assume_role(
+                &context,
+                AssumeRoleRequest {
+                    role_arn: "arn:aws:iam::123456789012:role/LegacyRole".to_string(),
+                    role_session_name: "legacy-session".to_string(),
+                    duration_seconds: Some(3600),
+                    external_id: None,
+                    policy: None,
+                },
+                "arn:aws:iam::123456789012:user/alice",
+            )
+            .await
+            .unwrap();
+
+        assert!(response.assumed_role_user.arn.contains("LegacyRole"));
+    }
+
+    #[tokio::test]
+    async fn test_assume_role_with_aws_format_arn_unknown_role() {
+        let service = setup_service();
+        let context = test_context();
+
+        let result = service
+            .assume_role(
+                &context,
+                AssumeRoleRequest {
+                    role_arn: "arn:aws:iam::123456789012:role/Missing".to_string(),
+                    role_session_name: "legacy-session".to_string(),
+                    duration_seconds: Some(3600),
+                    external_id: None,
+                    policy: None,
+                },
+                "arn:aws:iam::123456789012:user/alice",
+            )
+            .await;
+
+        assert!(matches!(result, Err(AmiError::ResourceNotFound { .. })));
+    }
+
+    #[tokio::test]
     async fn test_assume_role_with_external_id() {
         let service = setup_service();
         let context = test_context();

--- a/crates/wami/src/service/sts/federation.rs
+++ b/crates/wami/src/service/sts/federation.rs
@@ -9,7 +9,8 @@ use crate::wami::sts::federation::{
 use crate::wami::sts::session::SessionStatus;
 use crate::wami::sts::{Credentials, StsSession};
 use chrono::{Duration, Utc};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::arn::{Service, WamiArn};
 use wami_core::context::WamiContext;
 use wami_core::error::Result;
@@ -157,7 +158,7 @@ impl<S: SessionStore> FederationService<S> {
             last_used: None,
         };
 
-        self.write_store().create_session(session).await?;
+        self.write_store().await.create_session(session).await?;
 
         Ok(GetFederationTokenResponse {
             credentials,
@@ -268,7 +269,7 @@ mod tests {
         let sessions = service
             .store
             .read()
-            .unwrap()
+            .await
             .list_sessions(None)
             .await
             .unwrap();

--- a/crates/wami/src/service/sts/identity.rs
+++ b/crates/wami/src/service/sts/identity.rs
@@ -5,7 +5,8 @@
 use crate::provider::{AwsProvider, CloudProvider};
 use crate::store::traits::{IdentityStore, UserStore};
 use crate::wami::sts::CallerIdentity;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::error::{AmiError, Result};
 
 pub trait StsIdentityServiceStore: IdentityStore + UserStore {}
@@ -67,7 +68,7 @@ impl<S: StsIdentityServiceStore> IdentityService<S> {
     ) -> Result<GetCallerIdentityResponse> {
         // Try to get from identity store first
         {
-            let store_guard = self.store.read().expect("store read lock poisoned");
+            let store_guard = self.store.read().await;
             if let Some(identity) = store_guard.get_identity(caller_arn).await? {
                 return Ok(GetCallerIdentityResponse {
                     user_id: identity.user_id,
@@ -83,7 +84,7 @@ impl<S: StsIdentityServiceStore> IdentityService<S> {
 
         // Get user (drop read lock before creating identity)
         let user = {
-            let store_guard = self.store.read().expect("store read lock poisoned");
+            let store_guard = self.store.read().await;
             store_guard.get_user(&user_name).await?
         }; // Drop read lock
 
@@ -98,7 +99,7 @@ impl<S: StsIdentityServiceStore> IdentityService<S> {
             };
 
             {
-                let mut store_guard = self.store.write().expect("store write lock poisoned");
+                let mut store_guard = self.store.write().await;
                 store_guard.create_identity(identity.clone()).await?;
             } // Drop write lock
 
@@ -116,11 +117,7 @@ impl<S: StsIdentityServiceStore> IdentityService<S> {
 
     /// List all identities
     pub async fn list_identities(&self) -> Result<Vec<CallerIdentity>> {
-        self.store
-            .read()
-            .expect("store read lock poisoned")
-            .list_identities()
-            .await
+        self.store.read().await.list_identities().await
     }
 
     // Helper method
@@ -182,13 +179,7 @@ mod tests {
 
         let user_arn = user.arn.clone();
 
-        service
-            .store
-            .write()
-            .unwrap()
-            .create_user(user)
-            .await
-            .unwrap();
+        service.store.write().await.create_user(user).await.unwrap();
 
         // Get caller identity
         let request = GetCallerIdentityRequest {};
@@ -211,13 +202,7 @@ mod tests {
             let user = build_user(format!("user{}", i), Some("/".to_string()), &context).unwrap();
             let arn = user.arn.clone();
 
-            service
-                .store
-                .write()
-                .unwrap()
-                .create_user(user)
-                .await
-                .unwrap();
+            service.store.write().await.create_user(user).await.unwrap();
 
             // Trigger identity creation
             let request = GetCallerIdentityRequest {};

--- a/crates/wami/src/service/sts/session.rs
+++ b/crates/wami/src/service/sts/session.rs
@@ -5,7 +5,8 @@
 use crate::provider::{AwsProvider, CloudProvider};
 use crate::store::traits::SessionStore;
 use crate::wami::sts::StsSession;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::error::Result;
 
 /// Service for managing STS sessions
@@ -43,38 +44,22 @@ impl<S: SessionStore> SessionService<S> {
 
     /// Create a new STS session
     pub async fn create_session(&self, session: StsSession) -> Result<StsSession> {
-        self.store
-            .write()
-            .expect("store write lock poisoned")
-            .create_session(session)
-            .await
+        self.store.write().await.create_session(session).await
     }
 
     /// Get a session by session token
     pub async fn get_session(&self, session_token: &str) -> Result<Option<StsSession>> {
-        self.store
-            .read()
-            .expect("store read lock poisoned")
-            .get_session(session_token)
-            .await
+        self.store.read().await.get_session(session_token).await
     }
 
     /// Delete a session
     pub async fn delete_session(&self, session_token: &str) -> Result<()> {
-        self.store
-            .write()
-            .unwrap()
-            .delete_session(session_token)
-            .await
+        self.store.write().await.delete_session(session_token).await
     }
 
     /// List sessions, optionally filtered by user ID
     pub async fn list_sessions(&self, user_id: Option<&str>) -> Result<Vec<StsSession>> {
-        self.store
-            .read()
-            .expect("store read lock poisoned")
-            .list_sessions(user_id)
-            .await
+        self.store.read().await.list_sessions(user_id).await
     }
 }
 

--- a/crates/wami/src/service/sts/session_token.rs
+++ b/crates/wami/src/service/sts/session_token.rs
@@ -7,7 +7,8 @@ use crate::wami::sts::session::SessionStatus;
 use crate::wami::sts::session_token::GetSessionTokenRequest;
 use crate::wami::sts::{Credentials, StsSession};
 use chrono::{Duration, Utc};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::arn::{Service, WamiArn};
 use wami_core::context::WamiContext;
 use wami_core::error::Result;
@@ -146,7 +147,7 @@ impl<S: SessionStore> SessionTokenService<S> {
             last_used: None,
         };
 
-        self.write_store().create_session(session).await?;
+        self.write_store().await.create_session(session).await?;
 
         Ok(GetSessionTokenResponse { credentials })
     }
@@ -254,7 +255,7 @@ mod tests {
         let sessions = service
             .store
             .read()
-            .unwrap()
+            .await
             .list_sessions(None)
             .await
             .unwrap();

--- a/crates/wami/src/service/tenant/mod.rs
+++ b/crates/wami/src/service/tenant/mod.rs
@@ -553,4 +553,32 @@ mod tests {
         // IDs should be different (even though both are root tenants)
         assert_ne!(tenant1.id, tenant2.id);
     }
+
+    #[tokio::test]
+    async fn test_effective_quotas_and_usage() {
+        let service = setup_service();
+        let context = test_context();
+        let tenant = service
+            .create_tenant(&context, "acme".to_string(), None, None)
+            .await
+            .unwrap();
+
+        // A fresh tenant carries the default quotas and no usage yet.
+        let quotas = service.get_effective_quotas(&tenant.id).await.unwrap();
+        assert_eq!(quotas.max_users, tenant.quotas.max_users);
+        assert_eq!(quotas.max_roles, tenant.quotas.max_roles);
+
+        let usage = service.get_tenant_usage(&tenant.id).await.unwrap();
+        assert_eq!(usage.tenant_id, tenant.id);
+        assert_eq!(usage.current_users, 0);
+    }
+
+    #[tokio::test]
+    async fn test_quotas_and_usage_reject_unknown_tenant() {
+        let service = setup_service();
+        let missing = TenantId::from_string("99999999").unwrap();
+
+        assert!(service.get_effective_quotas(&missing).await.is_err());
+        assert!(service.get_tenant_usage(&missing).await.is_err());
+    }
 }

--- a/crates/wami/src/service/tenant/mod.rs
+++ b/crates/wami/src/service/tenant/mod.rs
@@ -5,7 +5,8 @@
 use crate::store::traits::TenantStore;
 use crate::wami::tenant::operations::tenant_operations;
 use crate::wami::tenant::{Tenant, TenantId, TenantQuotas, TenantUsage};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 use wami_core::arn::{Service, WamiArn};
 use wami_core::context::WamiContext;
 use wami_core::error::Result;
@@ -34,7 +35,7 @@ impl<S: TenantStore> TenantService<S> {
             };
 
             // Check global uniqueness - verify tenant doesn't already exist
-            let exists = self.read_store().get_tenant(&tenant_id).await?;
+            let exists = self.read_store().await.get_tenant(&tenant_id).await?;
 
             if exists.is_none() {
                 return Ok(tenant_id);
@@ -147,52 +148,55 @@ impl<S: TenantStore> TenantService<S> {
             .to_string();
 
         // Persist
-        self.write_store().create_tenant(tenant).await
+        self.write_store().await.create_tenant(tenant).await
     }
 
     /// Get a tenant by ID
     pub async fn get_tenant(&self, tenant_id: &TenantId) -> Result<Option<Tenant>> {
-        self.read_store().get_tenant(tenant_id).await
+        self.read_store().await.get_tenant(tenant_id).await
     }
 
     /// Update a tenant
     pub async fn update_tenant(&self, tenant: Tenant) -> Result<Tenant> {
-        self.write_store().update_tenant(tenant).await
+        self.write_store().await.update_tenant(tenant).await
     }
 
     /// Delete a tenant
     pub async fn delete_tenant(&self, tenant_id: &TenantId) -> Result<()> {
-        self.write_store().delete_tenant(tenant_id).await
+        self.write_store().await.delete_tenant(tenant_id).await
     }
 
     /// List all tenants
     pub async fn list_tenants(&self) -> Result<Vec<Tenant>> {
-        self.read_store().list_tenants().await
+        self.read_store().await.list_tenants().await
     }
 
     /// List child tenants of a parent
     pub async fn list_child_tenants(&self, parent_id: &TenantId) -> Result<Vec<Tenant>> {
-        self.read_store().list_child_tenants(parent_id).await
+        self.read_store().await.list_child_tenants(parent_id).await
     }
 
     /// Get all ancestors of a tenant
     pub async fn get_ancestors(&self, tenant_id: &TenantId) -> Result<Vec<Tenant>> {
-        self.read_store().get_ancestors(tenant_id).await
+        self.read_store().await.get_ancestors(tenant_id).await
     }
 
     /// Get all descendants of a tenant
     pub async fn get_descendants(&self, tenant_id: &TenantId) -> Result<Vec<TenantId>> {
-        self.read_store().get_descendants(tenant_id).await
+        self.read_store().await.get_descendants(tenant_id).await
     }
 
     /// Get effective quotas for a tenant (considering hierarchy)
     pub async fn get_effective_quotas(&self, tenant_id: &TenantId) -> Result<TenantQuotas> {
-        self.read_store().get_effective_quotas(tenant_id).await
+        self.read_store()
+            .await
+            .get_effective_quotas(tenant_id)
+            .await
     }
 
     /// Get current usage for a tenant
     pub async fn get_tenant_usage(&self, tenant_id: &TenantId) -> Result<TenantUsage> {
-        self.read_store().get_tenant_usage(tenant_id).await
+        self.read_store().await.get_tenant_usage(tenant_id).await
     }
 }
 

--- a/crates/wami/tests/one_store_many_services.rs
+++ b/crates/wami/tests/one_store_many_services.rs
@@ -1,0 +1,121 @@
+//! What #115 was about, from the outside.
+//!
+//! Two properties a consumer needs and could not have while the services
+//! disagreed on their lock type:
+//!
+//! 1. One store handle serves every service. When `TenantService` took
+//!    `std::sync::RwLock` and `AuthenticationService` took `tokio::sync::RwLock`,
+//!    the two were distinct types, so anything needing both had to hold two
+//!    handles onto the same data and hope they agreed.
+//!
+//! 2. The futures are `Send`. A `std::sync` guard held across an `.await` — which
+//!    is what the services did, since the store traits are async — makes the
+//!    future non-`Send`, so it cannot be spawned on a multi-threaded runtime nor
+//!    handed to a server framework.
+//!
+//! These are compile-time properties as much as runtime ones: the file failing
+//! to build is the regression.
+
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use wami::store::memory::InMemoryWamiStore;
+use wami::{
+    AuthenticationService, CreateUserRequest, InstanceBootstrap, TenantService, UserService,
+};
+use wami_core::context::WamiContext;
+
+/// Accepts only a `Send` future. Calling it is the assertion.
+fn assert_send<F: Send>(_: F) {}
+
+/// A store with an instance bootstrapped on it, and the root context to drive it.
+async fn bootstrapped() -> (Arc<RwLock<InMemoryWamiStore>>, WamiContext) {
+    let store = Arc::new(RwLock::new(InMemoryWamiStore::default()));
+    let root = InstanceBootstrap::initialize_instance(store.clone(), "999888777")
+        .await
+        .unwrap();
+    let context = AuthenticationService::new(store.clone())
+        .authenticate(&root.access_key_id, &root.secret_access_key)
+        .await
+        .unwrap();
+    (store, context)
+}
+
+#[tokio::test]
+async fn one_store_handle_serves_every_service() {
+    // Bootstrap and authentication took the handle...
+    let (store, context) = bootstrapped().await;
+
+    // ...and so do the services that used to want the other lock type.
+    let tenants = TenantService::new(store.clone());
+    let users = UserService::new(store.clone());
+
+    let tenant = tenants
+        .create_tenant(&context, "acme".to_string(), None, None)
+        .await
+        .unwrap();
+
+    users
+        .create_user(
+            &context,
+            CreateUserRequest {
+                user_name: "alice".to_string(),
+                path: Some("/".to_string()),
+                permissions_boundary: None,
+                tags: None,
+            },
+        )
+        .await
+        .unwrap();
+
+    // One store, so each write is visible through the other handle.
+    assert!(tenants.get_tenant(&tenant.id).await.unwrap().is_some());
+    assert!(users.get_user(&context, "alice").await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn service_futures_are_send() {
+    let (store, context) = bootstrapped().await;
+    let tenants = TenantService::new(store.clone());
+    let users = UserService::new(store.clone());
+
+    // A read and a write on each, since both guards used to be the blocking kind.
+    assert_send(tenants.list_tenants());
+    assert_send(tenants.create_tenant(&context, "acme".to_string(), None, None));
+    assert_send(users.get_user(&context, "alice"));
+    assert_send(users.create_user(
+        &context,
+        CreateUserRequest {
+            user_name: "bob".to_string(),
+            path: None,
+            permissions_boundary: None,
+            tags: None,
+        },
+    ));
+}
+
+/// `tokio::spawn` demands `Send + 'static` — the shape a server framework needs.
+/// Non-`Send` futures were rejected here before anything ran.
+#[tokio::test(flavor = "multi_thread")]
+async fn service_calls_can_be_spawned_on_a_multi_thread_runtime() {
+    let (store, context) = bootstrapped().await;
+    let tenants = Arc::new(TenantService::new(store.clone()));
+
+    let handles: Vec<_> = (0..4)
+        .map(|i| {
+            let tenants = tenants.clone();
+            let context = context.clone();
+            tokio::spawn(async move {
+                tenants
+                    .create_tenant(&context, format!("tenant-{i}"), None, None)
+                    .await
+                    .unwrap()
+            })
+        })
+        .collect();
+
+    for handle in handles {
+        handle.await.unwrap();
+    }
+
+    assert_eq!(tenants.list_tenants().await.unwrap().len(), 4);
+}

--- a/docs/CONDITION_KEYS_GUIDE.md
+++ b/docs/CONDITION_KEYS_GUIDE.md
@@ -11,7 +11,8 @@ Policy condition keys enable fine-grained access control by evaluating contextua
 ```rust
 use wami::service::policies::evaluation::{EvaluationService, SimulateCustomPolicyRequest, ContextEntry};
 use wami::store::memory::InMemoryWamiStore;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -458,7 +459,8 @@ use wami::service::policies::evaluation::{
     EvaluationService, SimulateCustomPolicyRequest, ContextEntry,
 };
 use wami::store::memory::InMemoryWamiStore;
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/docs/INSTANCE_BOOTSTRAP_GUIDE.md
+++ b/docs/INSTANCE_BOOTSTRAP_GUIDE.md
@@ -64,7 +64,8 @@ let context = auth_service
 
 ```rust
 use wami::{InstanceBootstrap, InMemoryStore};
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/docs/status/IMPLEMENTATION_STATUS.md
+++ b/docs/status/IMPLEMENTATION_STATUS.md
@@ -96,7 +96,8 @@ use wami::{
     InstanceBootstrap, AuthenticationService,
     UserService, InMemoryStore,
 };
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {

--- a/docs/status/SECURITY_AUTHENTICATION_COMPLETE.md
+++ b/docs/status/SECURITY_AUTHENTICATION_COMPLETE.md
@@ -409,7 +409,8 @@ use wami::{
     InstanceBootstrap, AuthenticationService,
     UserService, InMemoryStore,
 };
-use std::sync::{Arc, RwLock};
+use std::sync::Arc;
+use tokio::sync::RwLock;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
Closes #115.

## The two problems, one cause

Twenty-nine services took `Arc<std::sync::RwLock<S>>`; `auth/authentication.rs` and `auth/authorization.rs` took `Arc<tokio::sync::RwLock<S>>`.

**The locks disagreed with each other.** Distinct types, so one store could not be handed to both — anything needing a tenant service and an authentication service at once held two handles onto the same data and hoped they agreed. Example 26 carried that exact workaround, in a comment:

```rust
// let std_store = Arc::new(StdRwLock::new(store.read().await.wami_store.clone()));
// let user_service = UserService::new(std_store);
```

It now just passes the one handle, and actually creates the user.

**A synchronous guard was held across an await.** The store traits are `#[async_trait]`, so `self.write_store().create_user(user).await` kept a blocking guard alive across the await point. One task waiting on a slow store blocks a runtime thread, and the futures are not `Send` — they cannot be spawned, nor handed to a server framework.

Two `#![allow(clippy::await_holding_lock)]`, in `service/mod.rs` and `service/gdpr/mod.rs`, were silencing precisely this. **Both are removed, and clippy is clean without them** — that is the check that the pattern is actually gone rather than moved.

## What changed

- **`#[service]` macro** — generates `tokio::sync::RwLock`; `read_store()`/`write_store()` are async, and there is no poisoning left to report.
- **29 services** — `use std::sync::{Arc, RwLock}` → `use std::sync::Arc; use tokio::sync::RwLock;`, and 142 `read_store()`/`write_store()` call sites plus 37 direct `.read().unwrap()`/`.write().unwrap()` gain their `.await`.
- **23 examples + 2 guides + the macro README** — same swap.

`wami-service`'s `Registry` deliberately keeps `std::sync::RwLock`: its trait is synchronous and no guard ever meets an await. Converting it would add an async requirement for nothing.

## Tests

New `crates/wami/tests/one_store_many_services.rs` pins both properties from a consumer's point of view — the file failing to build *is* the regression:

- `one_store_handle_serves_every_service` — one `Arc<RwLock<InMemoryWamiStore>>` drives bootstrap, authentication, `TenantService` and `UserService`, and each write is visible through the other handle
- `service_futures_are_send` — `fn assert_send<F: Send>(_: F)` over a read and a write on each service
- `service_calls_can_be_spawned_on_a_multi_thread_runtime` — `tokio::spawn` on a multi-thread runtime, which demands `Send + 'static`

## Verification

- `cargo test --workspace --all-features` — all green (743 + 368 + 190 + the 3 new + doctests)
- `cargo clippy --workspace --all-targets --all-features` — silent, *with the two allows removed*
- `cargo fmt --all --check` — clean
- All 27 examples run to completion under a 30 s watchdog. Five fail (`06`, `07`, `19`, `21`, `25`) — verified against a `main` worktree, they fail identically there with the same exit codes. Pre-existing, untouched here. **No deadlock**, which was the real risk given tokio's write-preferring lock.

## Breaking change

Every service constructor takes `Arc<tokio::sync::RwLock<S>>` instead of `Arc<std::sync::RwLock<S>>`, and `store()` returns the same. Callers swap `use std::sync::RwLock` for `use tokio::sync::RwLock`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)