### PR TITLE
feat(auth)!: authorize returns a motivated Decision, and an unreadable policy is an error

### DIFF
--- a/crates/wami-core/src/error.rs
+++ b/crates/wami-core/src/error.rs
@@ -50,6 +50,22 @@ pub enum AmiError {
 
     #[error("Store error: {0}")]
     StoreError(String),
+
+    /// A policy document could not be parsed, so no decision can be made from it.
+    ///
+    /// Deliberately an error and not a denial. A denial means "the rules
+    /// forbid this"; an unreadable policy means "the rules cannot be read" —
+    /// and the caller must be able to tell those apart, because the first is a
+    /// 403 the user can act on and the second is a corrupt store that should
+    /// page someone. Folding it into `AccessDenied` would hide a broken policy
+    /// store behind what looks like an ordinary permission failure.
+    #[error("policy cannot be read ({policy}): {message}")]
+    UnreadablePolicy {
+        /// Which policy failed to parse, so an operator knows what to fix.
+        policy: String,
+        /// What the parser objected to.
+        message: String,
+    },
 }
 
 pub type Result<T> = std::result::Result<T, AmiError>;

--- a/crates/wami-core/src/types.rs
+++ b/crates/wami-core/src/types.rs
@@ -97,6 +97,20 @@ pub struct PolicyDocument {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PolicyStatement {
+    /// Optional statement id, as AWS defines it.
+    ///
+    /// An audit line has to name the statement that decided. Without a `Sid`
+    /// the only handle left is the statement's index in the document, and an
+    /// index recorded today points at a different statement once the policy is
+    /// rewritten — a log that is worse than silent, because it is confidently
+    /// wrong.
+    ///
+    /// Adding it is backward compatible in both directions: the struct does
+    /// not deny unknown fields, so documents already carrying a `Sid` are
+    /// accepted today and merely drop it, and `skip_serializing_if` keeps
+    /// documents without one byte-identical when re-serialised.
+    #[serde(rename = "Sid", default, skip_serializing_if = "Option::is_none")]
+    pub sid: Option<String>,
     #[serde(rename = "Effect")]
     pub effect: String,
     #[serde(rename = "Action", deserialize_with = "string_or_vec")]

--- a/crates/wami/src/service/auth/authorization.rs
+++ b/crates/wami/src/service/auth/authorization.rs
@@ -1814,4 +1814,109 @@ mod tests {
             .expect_err("valid JSON that is not a valid policy must be refused");
         assert!(matches!(err, AmiError::InvalidParameter { .. }), "{err:?}");
     }
+
+    #[tokio::test]
+    async fn check_or_deny_quotes_the_reason_it_refused() {
+        // The convenience wrapper must not throw away the motivation — that is
+        // the whole point of the change for callers that never touch Decision.
+        let ctx = test_context();
+        let store = setup_store_with_user(&ctx).await;
+        store
+            .write()
+            .await
+            .put_user_policy("alice", "Blocked", deny_policy_json(&["iam:*"], &["*"]))
+            .await
+            .unwrap();
+
+        let authz = AuthorizationService::new(store);
+        let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
+
+        let err = authz
+            .check_or_deny(&ctx, "iam:GetUser", &resource)
+            .await
+            .expect_err("an explicit deny must refuse");
+        let AmiError::AccessDenied { message } = &err else {
+            panic!("expected AccessDenied, got {err:?}");
+        };
+        assert!(message.contains("denied by"), "{message}");
+        assert!(message.contains("Blocked"), "{message}");
+    }
+
+    #[tokio::test]
+    async fn check_or_deny_passes_when_allowed() {
+        let ctx = test_context();
+        let store = setup_store_with_user(&ctx).await;
+        store
+            .write()
+            .await
+            .put_user_policy("alice", "Allow", allow_policy_json(&["iam:*"], &["*"]))
+            .await
+            .unwrap();
+
+        let authz = AuthorizationService::new(store);
+        let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
+        authz
+            .check_or_deny(&ctx, "iam:GetUser", &resource)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_managed_policy_attached_to_the_user_is_evaluated() {
+        // The inline path was covered; the managed one was not.
+        let ctx = test_context();
+        let store = setup_store_with_user(&ctx).await;
+        {
+            let mut s = store.write().await;
+            let policy = policy_builder::build_policy(
+                "ReadOnly".to_string(),
+                allow_policy_json(&["iam:GetUser"], &["*"]),
+                None,
+                None,
+                None,
+                &ctx,
+            )
+            .unwrap();
+            let arn = policy.arn.clone();
+            s.create_policy(policy).await.unwrap();
+            s.attach_user_policy("alice", &arn).await.unwrap();
+        }
+
+        let authz = AuthorizationService::new(store);
+        let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
+        let decision = authz
+            .authorize(&ctx, "iam:GetUser", &resource)
+            .await
+            .unwrap();
+
+        let Decision::Allow(AllowReason::Statements(refs)) = &decision else {
+            panic!("expected an allow from the managed policy, got {decision:?}");
+        };
+        assert!(matches!(
+            refs.first().policy,
+            PolicySource::UserManaged { .. }
+        ));
+    }
+
+    #[tokio::test]
+    async fn a_missing_user_cannot_have_a_boundary_to_apply() {
+        // The caller is authenticated but the user record is gone. There is no
+        // boundary to intersect with, so an allow already found stands.
+        let ctx = test_context();
+        let store = Arc::new(RwLock::new(InMemoryWamiStore::default()));
+        store
+            .write()
+            .await
+            .put_user_policy("alice", "Allow", allow_policy_json(&["iam:*"], &["*"]))
+            .await
+            .unwrap();
+
+        let authz = AuthorizationService::new(store);
+        let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
+        assert!(authz
+            .authorize(&ctx, "iam:GetUser", &resource)
+            .await
+            .unwrap()
+            .is_allowed());
+    }
 }

--- a/crates/wami/src/service/auth/authorization.rs
+++ b/crates/wami/src/service/auth/authorization.rs
@@ -22,22 +22,25 @@
 //!     let context = todo!("Get from authentication");
 //!     let resource_arn: WamiArn = "arn:wami:iam:12345678:wami:999:user/alice".parse()?;
 //!
-//!     // Check if user can perform action
-//!     let allowed = authz_service
+//!     // The decision carries why it went that way, so it can be logged or
+//!     // shown to the user as-is.
+//!     let decision = authz_service
 //!         .authorize(&context, "iam:GetUser", &resource_arn)
 //!         .await?;
 //!
-//!     if allowed {
-//!         println!("Access granted");
-//!     } else {
-//!         println!("Access denied");
+//!     println!("{decision}");
+//!     if decision.is_allowed() {
+//!         // ...
 //!     }
 //!
 //!     Ok(())
 //! }
 //! ```
 
-use crate::service::auth::policy_evaluator::{self, PolicyEffect};
+use crate::service::auth::decision::{
+    AllowReason, Decision, DenyReason, NonEmpty, PolicySource, StatementRef,
+};
+use crate::service::auth::policy_evaluator::{self, PolicyEffect, StatementHit};
 use crate::store::traits::{GroupStore, PolicyStore, RoleStore, UserStore};
 use std::sync::Arc;
 use tokio::sync::RwLock;
@@ -89,130 +92,123 @@ where
         context: &WamiContext,
         action: &str,
         resource_arn: &WamiArn,
-    ) -> Result<bool> {
-        // Root users bypass all authorization checks
+    ) -> Result<Decision> {
+        // Root bypasses everything, permissions boundary included — as it does
+        // in AWS, where boundaries do not apply to the account root.
         if context.is_root() {
-            return Ok(true);
+            return Ok(Decision::Allow(AllowReason::RootBypass));
         }
 
-        // Extract user name from caller ARN
         let user_name = self.extract_user_name_from_arn(context.caller_arn())?;
 
-        // Evaluate policies for this user
         self.evaluate_user_policies(context, &user_name, action, resource_arn)
             .await
     }
 
     /// Check if access is denied (returns an error if not authorized)
     ///
-    /// This is a convenience method that throws an `AccessDenied` error
-    /// if the authorization check fails.
+    /// Convenience wrapper over [`AuthorizationService::authorize`] for callers
+    /// that only need to proceed or stop. The refusal names what decided, so a
+    /// caller gets a usable message without handling [`Decision`] itself.
     pub async fn check_or_deny(
         &self,
         context: &WamiContext,
         action: &str,
         resource_arn: &WamiArn,
     ) -> Result<()> {
-        let allowed = self.authorize(context, action, resource_arn).await?;
-
-        if !allowed {
-            return Err(AmiError::AccessDenied {
+        match self.authorize(context, action, resource_arn).await? {
+            Decision::Allow(_) => Ok(()),
+            denied => Err(AmiError::AccessDenied {
                 message: format!(
-                    "User {} is not authorized to perform {} on {}",
+                    "{} is not authorized to perform {} on {}: {}",
                     context.caller_arn(),
                     action,
-                    resource_arn
+                    resource_arn,
+                    denied
                 ),
-            });
+            }),
         }
-
-        Ok(())
     }
 
     /// Evaluate all policies for a user
     ///
-    /// This includes:
-    /// - User's attached managed policies
-    /// - User's inline policies
-    /// - Policies from user's groups (attached + inline)
-    /// - Policies from assumed role (if session has one)
+    /// Collects from every source — the user's managed and inline policies,
+    /// those of their groups, and those of an assumed role — then applies
+    /// deny-overrides-allow across the whole set, and finally intersects with
+    /// the permissions boundary.
     ///
-    /// **Deny-overrides-allow**: an explicit Deny from ANY source wins over
-    /// an Allow from any other source.
+    /// The collected sources are sorted before anything is reported. That sort
+    /// is where determinism comes from: `GroupStore::list_groups_for_user` and
+    /// friends promise no ordering, so a SQL backend without an `ORDER BY`
+    /// could hand back the same policies in a different order on two identical
+    /// calls. Sorting by [`PolicySource`] reproduces the intended precedence —
+    /// user, then group, then role — no matter what the store did.
     async fn evaluate_user_policies(
         &self,
         context: &WamiContext,
         user_name: &str,
         action: &str,
         resource_arn: &WamiArn,
-    ) -> Result<bool> {
+    ) -> Result<Decision> {
         let store = self.store.read().await;
 
-        // Collect all policy documents from every source, then apply
-        // deny-overrides-allow across the whole set.
-        let mut all_effects: Vec<PolicyEffect> = Vec::new();
+        let mut hits: Vec<(PolicySource, StatementHit)> = Vec::new();
+
+        // Evaluate one document, recording which source it came from. An
+        // unreadable document aborts the whole decision rather than being
+        // skipped: it might have held a deny, and there is no way to know.
+        let mut consider = |document: &str, source: PolicySource| -> Result<()> {
+            let parsed = policy_evaluator::parse_policy_doc(document, &source)?;
+            if let Some(hit) =
+                policy_evaluator::evaluate_policy_document(&parsed, action, resource_arn, context)
+            {
+                hits.push((source, hit));
+            }
+            Ok(())
+        };
 
         // ── 1. User attached managed policies ──────────────────────
-        let attached_policies = store.list_attached_user_policies(user_name).await?;
-        for policy_arn in attached_policies {
+        for policy_arn in store.list_attached_user_policies(user_name).await? {
             if let Some(policy) = store.get_policy(&policy_arn).await? {
-                let doc = policy_evaluator::parse_policy_doc(&policy.policy_document);
-                all_effects.push(policy_evaluator::evaluate_policy_document(
-                    &doc,
-                    action,
-                    resource_arn,
-                    context,
-                ));
+                consider(
+                    &policy.policy_document,
+                    PolicySource::UserManaged { arn: policy_arn },
+                )?;
             }
         }
 
         // ── 2. User inline policies ────────────────────────────────
-        let inline_policies = store.list_user_policies(user_name).await?;
-        for policy_name in inline_policies {
-            if let Some(doc_str) = store.get_user_policy(user_name, &policy_name).await? {
-                let doc = policy_evaluator::parse_policy_doc(&doc_str);
-                all_effects.push(policy_evaluator::evaluate_policy_document(
-                    &doc,
-                    action,
-                    resource_arn,
-                    context,
-                ));
+        for policy_name in store.list_user_policies(user_name).await? {
+            if let Some(document) = store.get_user_policy(user_name, &policy_name).await? {
+                consider(&document, PolicySource::UserInline { name: policy_name })?;
             }
         }
 
         // ── 3. Group policies (attached + inline) ──────────────────
-        let groups = store.list_groups_for_user(user_name).await?;
-        for group in &groups {
-            // Group attached managed policies
-            let group_attached = store
-                .list_attached_group_policies(&group.group_name)
-                .await?;
-            for policy_arn in group_attached {
+        for group in store.list_groups_for_user(user_name).await? {
+            let group_name = &group.group_name;
+
+            for policy_arn in store.list_attached_group_policies(group_name).await? {
                 if let Some(policy) = store.get_policy(&policy_arn).await? {
-                    let doc = policy_evaluator::parse_policy_doc(&policy.policy_document);
-                    all_effects.push(policy_evaluator::evaluate_policy_document(
-                        &doc,
-                        action,
-                        resource_arn,
-                        context,
-                    ));
+                    consider(
+                        &policy.policy_document,
+                        PolicySource::GroupManaged {
+                            group: group_name.clone(),
+                            arn: policy_arn,
+                        },
+                    )?;
                 }
             }
 
-            // Group inline policies
-            let group_inline = store.list_group_policies(&group.group_name).await?;
-            for policy_name in group_inline {
-                if let Some(doc_str) = store
-                    .get_group_policy(&group.group_name, &policy_name)
-                    .await?
-                {
-                    let doc = policy_evaluator::parse_policy_doc(&doc_str);
-                    all_effects.push(policy_evaluator::evaluate_policy_document(
-                        &doc,
-                        action,
-                        resource_arn,
-                        context,
-                    ));
+            for policy_name in store.list_group_policies(group_name).await? {
+                if let Some(document) = store.get_group_policy(group_name, &policy_name).await? {
+                    consider(
+                        &document,
+                        PolicySource::GroupInline {
+                            group: group_name.clone(),
+                            name: policy_name,
+                        },
+                    )?;
                 }
             }
         }
@@ -223,80 +219,113 @@ where
                 if role_arn.resource.resource_type == "role" {
                     let role_name = &role_arn.resource.resource_id;
 
-                    // Role attached managed policies
-                    let role_attached = store.list_attached_role_policies(role_name).await?;
-                    for policy_arn in role_attached {
+                    for policy_arn in store.list_attached_role_policies(role_name).await? {
                         if let Some(policy) = store.get_policy(&policy_arn).await? {
-                            let doc = policy_evaluator::parse_policy_doc(&policy.policy_document);
-                            all_effects.push(policy_evaluator::evaluate_policy_document(
-                                &doc,
-                                action,
-                                resource_arn,
-                                context,
-                            ));
+                            consider(
+                                &policy.policy_document,
+                                PolicySource::RoleManaged {
+                                    role: role_name.clone(),
+                                    arn: policy_arn,
+                                },
+                            )?;
                         }
                     }
 
-                    // Role inline policies
-                    let role_inline = store.list_role_policies(role_name).await?;
-                    for policy_name in role_inline {
-                        if let Some(doc_str) =
+                    for policy_name in store.list_role_policies(role_name).await? {
+                        if let Some(document) =
                             store.get_role_policy(role_name, &policy_name).await?
                         {
-                            let doc = policy_evaluator::parse_policy_doc(&doc_str);
-                            all_effects.push(policy_evaluator::evaluate_policy_document(
-                                &doc,
-                                action,
-                                resource_arn,
-                                context,
-                            ));
+                            consider(
+                                &document,
+                                PolicySource::RoleInline {
+                                    role: role_name.clone(),
+                                    name: policy_name,
+                                },
+                            )?;
                         }
                     }
                 }
             }
         }
 
-        // ── 5. Deny-overrides-allow resolution ─────────────────────
-        // An explicit Deny from ANY policy source overrides all Allows.
-        if all_effects.contains(&PolicyEffect::Deny) {
-            return Ok(false);
+        // Canonical order — see the note on this function.
+        hits.sort_by(|(a, _), (b, _)| a.cmp(b));
+
+        let refs = |effect: PolicyEffect| -> Vec<StatementRef> {
+            hits.iter()
+                .filter(|(_, hit)| hit.effect == effect)
+                .map(|(source, hit)| StatementRef {
+                    policy: source.clone(),
+                    sid: hit.sid.clone(),
+                    index: hit.index,
+                })
+                .collect()
+        };
+
+        // ── 5. Deny-overrides-allow ────────────────────────────────
+        if let Ok(denied_by) = NonEmpty::new(refs(PolicyEffect::Deny)) {
+            return Ok(Decision::Deny(DenyReason::Statements(denied_by)));
         }
 
-        // If at least one policy allows, check permissions boundary.
-        if all_effects.contains(&PolicyEffect::Allow) {
-            // ── 6. Permissions boundary check ─────────────────────
-            // If the user has a permissions boundary, the effective permission is
-            // the INTERSECTION of the identity policies and the boundary.
-            // The action must be allowed by BOTH the policies AND the boundary.
-            if let Some(user) = store.get_user(user_name).await? {
-                if let Some(ref boundary_arn) = user.permissions_boundary {
-                    if let Some(boundary_policy) = store.get_policy(boundary_arn).await? {
-                        let boundary_doc =
-                            policy_evaluator::parse_policy_doc(&boundary_policy.policy_document);
-                        let boundary_effect = policy_evaluator::evaluate_policy_document(
-                            &boundary_doc,
-                            action,
-                            resource_arn,
-                            context,
-                        );
-                        if boundary_effect != PolicyEffect::Allow {
-                            // Boundary does not allow → effective deny
-                            return Ok(false);
-                        }
-                    }
-                    // If boundary policy not found, fail closed (deny)
-                    else {
-                        return Ok(false);
-                    }
-                }
+        // Nothing allowed it, so there is no statement to name. The boundary is
+        // deliberately not consulted here: it can only narrow permissions,
+        // never grant them, so with nothing to narrow it cannot change this.
+        let Ok(allowed_by) = NonEmpty::new(refs(PolicyEffect::Allow)) else {
+            return Ok(Decision::Deny(DenyReason::NoMatch));
+        };
+
+        // ── 6. Permissions boundary ────────────────────────────────
+        // Effective permissions are the intersection of the identity policies
+        // and the boundary: the action must be allowed by both.
+        let Some(user) = store.get_user(user_name).await? else {
+            return Ok(Decision::Allow(AllowReason::Statements(allowed_by)));
+        };
+        let Some(boundary_arn) = user.permissions_boundary else {
+            return Ok(Decision::Allow(AllowReason::Statements(allowed_by)));
+        };
+
+        let Some(boundary) = store.get_policy(&boundary_arn).await? else {
+            // Referenced but absent: a ceiling that cannot be read cannot be
+            // honoured, so fail closed.
+            return Ok(Decision::Deny(DenyReason::BoundaryMissing {
+                arn: boundary_arn,
+            }));
+        };
+
+        let boundary_source = PolicySource::PermissionsBoundary {
+            arn: boundary_arn.clone(),
+        };
+        let boundary_doc =
+            policy_evaluator::parse_policy_doc(&boundary.policy_document, &boundary_source)?;
+        let boundary_hit = policy_evaluator::evaluate_policy_document(
+            &boundary_doc,
+            action,
+            resource_arn,
+            context,
+        );
+
+        match boundary_hit {
+            Some(hit) if hit.effect == PolicyEffect::Allow => {
+                Ok(Decision::Allow(AllowReason::Statements(allowed_by)))
             }
-            return Ok(true);
+            // An explicit deny in the boundary and a boundary that simply does
+            // not cover the action are both refusals, but they call for
+            // opposite fixes — remove that statement, or widen the boundary.
+            // `denied_by` carries which one it was.
+            other => Ok(Decision::Deny(DenyReason::BoundaryRestricted {
+                arn: boundary_arn,
+                allowed_by,
+                denied_by: other
+                    .into_iter()
+                    .map(|hit| StatementRef {
+                        policy: boundary_source.clone(),
+                        sid: hit.sid,
+                        index: hit.index,
+                    })
+                    .collect(),
+            })),
         }
-
-        // Default deny — no policy explicitly allows.
-        Ok(false)
     }
-
     /// Extract user name from a user ARN
     fn extract_user_name_from_arn(&self, arn: &WamiArn) -> Result<String> {
         // Check if this is a user resource
@@ -483,12 +512,14 @@ mod tests {
             version: "2012-10-17".to_string(),
             statement: vec![
                 PolicyStatement {
+                    sid: None,
                     effect: "Allow".to_string(),
                     action: vec!["iam:*".to_string()],
                     resource: vec!["*".to_string()],
                     condition: None,
                 },
                 PolicyStatement {
+                    sid: None,
                     effect: "Deny".to_string(),
                     action: vec!["iam:DeleteUser".to_string()],
                     resource: vec!["*".to_string()],
@@ -503,7 +534,7 @@ mod tests {
             policy_evaluator::evaluate_policy_document(&policy, "iam:DeleteUser", &resource, &ctx);
 
         // Deny should override Allow
-        assert_eq!(effect, PolicyEffect::Deny);
+        assert_eq!(effect.map(|hit| hit.effect), Some(PolicyEffect::Deny));
     }
 
     #[test]
@@ -511,6 +542,7 @@ mod tests {
         let policy = PolicyDocument {
             version: "2012-10-17".to_string(),
             statement: vec![PolicyStatement {
+                sid: None,
                 effect: "Allow".to_string(),
                 action: vec!["s3:GetObject".to_string()],
                 resource: vec!["*".to_string()],
@@ -523,7 +555,7 @@ mod tests {
         let effect =
             policy_evaluator::evaluate_policy_document(&policy, "iam:GetUser", &resource, &ctx);
 
-        assert_eq!(effect, PolicyEffect::NoMatch);
+        assert!(effect.is_none());
     }
 
     #[test]
@@ -531,6 +563,7 @@ mod tests {
         let policy = PolicyDocument {
             version: "2012-10-17".to_string(),
             statement: vec![PolicyStatement {
+                sid: None,
                 effect: "DENY".to_string(), // Uppercase
                 action: vec!["iam:GetUser".to_string()],
                 resource: vec!["*".to_string()],
@@ -543,7 +576,7 @@ mod tests {
         let effect =
             policy_evaluator::evaluate_policy_document(&policy, "iam:GetUser", &resource, &ctx);
 
-        assert_eq!(effect, PolicyEffect::Deny);
+        assert_eq!(effect.map(|hit| hit.effect), Some(PolicyEffect::Deny));
     }
 
     /// Helper: minimal WamiContext for unit tests that only call evaluate_policy_document
@@ -647,7 +680,10 @@ mod tests {
             .authorize(&ctx, "iam:GetUser", &resource)
             .await
             .unwrap();
-        assert!(allowed, "Group attached policy should allow iam:GetUser");
+        assert!(
+            allowed.is_allowed(),
+            "Group attached policy should allow iam:GetUser"
+        );
     }
 
     #[tokio::test]
@@ -677,7 +713,10 @@ mod tests {
             .authorize(&ctx, "iam:DeleteUser", &resource)
             .await
             .unwrap();
-        assert!(allowed, "Group inline policy should allow iam:DeleteUser");
+        assert!(
+            allowed.is_allowed(),
+            "Group inline policy should allow iam:DeleteUser"
+        );
     }
 
     #[tokio::test]
@@ -716,14 +755,20 @@ mod tests {
             .authorize(&ctx, "iam:DeleteUser", &resource)
             .await
             .unwrap();
-        assert!(!allowed, "Group deny should override user allow");
+        assert!(
+            !allowed.is_allowed(),
+            "Group deny should override user allow"
+        );
 
         // But other actions should still be allowed
         let allowed_get = authz
             .authorize(&ctx, "iam:GetUser", &resource)
             .await
             .unwrap();
-        assert!(allowed_get, "iam:GetUser should still be allowed");
+        assert!(
+            allowed_get.is_allowed(),
+            "iam:GetUser should still be allowed"
+        );
     }
 
     #[tokio::test]
@@ -789,7 +834,10 @@ mod tests {
             .authorize(&ctx, "iam:CreateUser", &resource)
             .await
             .unwrap();
-        assert!(allowed, "Assumed role policy should allow iam:CreateUser");
+        assert!(
+            allowed.is_allowed(),
+            "Assumed role policy should allow iam:CreateUser"
+        );
     }
 
     #[tokio::test]
@@ -846,14 +894,17 @@ mod tests {
             .authorize(&ctx, "iam:GetUser", &resource)
             .await
             .unwrap();
-        assert!(allowed, "Role inline policy should allow iam:GetUser");
+        assert!(
+            allowed.is_allowed(),
+            "Role inline policy should allow iam:GetUser"
+        );
 
         let denied = authz
             .authorize(&ctx, "iam:DeleteUser", &resource)
             .await
             .unwrap();
         assert!(
-            !denied,
+            !denied.is_allowed(),
             "Role inline policy should not allow iam:DeleteUser"
         );
     }
@@ -936,14 +987,17 @@ mod tests {
             .authorize(&ctx, "iam:DeleteUser", &resource)
             .await
             .unwrap();
-        assert!(!denied, "Role deny must override user+group allow");
+        assert!(
+            !denied.is_allowed(),
+            "Role deny must override user+group allow"
+        );
 
         // Other actions still allowed
         let allowed = authz
             .authorize(&ctx, "iam:GetUser", &resource)
             .await
             .unwrap();
-        assert!(allowed, "iam:GetUser should still be allowed");
+        assert!(allowed.is_allowed(), "iam:GetUser should still be allowed");
     }
 
     #[tokio::test]
@@ -959,7 +1013,7 @@ mod tests {
             .authorize(&ctx, "iam:GetUser", &resource)
             .await
             .unwrap();
-        assert!(!allowed, "No policies → default deny");
+        assert!(!allowed.is_allowed(), "No policies → default deny");
     }
 
     #[tokio::test]
@@ -982,7 +1036,7 @@ mod tests {
             .authorize(&ctx, "iam:DeleteUser", &resource)
             .await
             .unwrap();
-        assert!(allowed, "Root user must bypass all checks");
+        assert!(allowed.is_allowed(), "Root user must bypass all checks");
     }
 
     #[tokio::test]
@@ -1027,16 +1081,19 @@ mod tests {
         assert!(authz
             .authorize(&ctx, "iam:GetUser", &resource)
             .await
-            .unwrap());
+            .unwrap()
+            .is_allowed());
         assert!(authz
             .authorize(&ctx, "iam:CreateUser", &resource)
             .await
-            .unwrap());
+            .unwrap()
+            .is_allowed());
         // But delete is not allowed by any group
         assert!(!authz
             .authorize(&ctx, "iam:DeleteUser", &resource)
             .await
-            .unwrap());
+            .unwrap()
+            .is_allowed());
     }
 
     // ========== Condition evaluation tests (P2.2) ==========
@@ -1086,8 +1143,8 @@ mod tests {
         let effect =
             policy_evaluator::evaluate_policy_document(&doc, "iam:GetUser", &resource, &ctx);
         assert_eq!(
-            effect,
-            PolicyEffect::Allow,
+            effect.map(|hit| hit.effect),
+            Some(PolicyEffect::Allow),
             "IP 10.1.2.3 should match 10.0.0.0/8"
         );
     }
@@ -1118,9 +1175,8 @@ mod tests {
 
         let effect =
             policy_evaluator::evaluate_policy_document(&doc, "iam:GetUser", &resource, &ctx);
-        assert_eq!(
-            effect,
-            PolicyEffect::NoMatch,
+        assert!(
+            effect.is_none(),
             "IP 192.168.1.1 should NOT match 10.0.0.0/8 → NoMatch"
         );
     }
@@ -1152,8 +1208,8 @@ mod tests {
         let effect =
             policy_evaluator::evaluate_policy_document(&doc, "iam:DeleteUser", &resource, &ctx);
         assert_eq!(
-            effect,
-            PolicyEffect::Allow,
+            effect.map(|hit| hit.effect),
+            Some(PolicyEffect::Allow),
             "MFA present → condition matches → Allow"
         );
     }
@@ -1184,11 +1240,7 @@ mod tests {
 
         let effect =
             policy_evaluator::evaluate_policy_document(&doc, "iam:DeleteUser", &resource, &ctx);
-        assert_eq!(
-            effect,
-            PolicyEffect::NoMatch,
-            "MFA absent → condition fails → NoMatch"
-        );
+        assert!(effect.is_none(), "MFA absent → condition fails → NoMatch");
     }
 
     #[test]
@@ -1197,6 +1249,7 @@ mod tests {
         let doc = PolicyDocument {
             version: "2012-10-17".to_string(),
             statement: vec![PolicyStatement {
+                sid: None,
                 effect: "Allow".to_string(),
                 action: vec!["iam:GetUser".to_string()],
                 resource: vec!["*".to_string()],
@@ -1210,8 +1263,8 @@ mod tests {
         let effect =
             policy_evaluator::evaluate_policy_document(&doc, "iam:GetUser", &resource, &ctx);
         assert_eq!(
-            effect,
-            PolicyEffect::Allow,
+            effect.map(|hit| hit.effect),
+            Some(PolicyEffect::Allow),
             "No condition → Allow (backward compat)"
         );
     }
@@ -1263,14 +1316,17 @@ mod tests {
             .authorize(&ctx, "iam:DeleteUser", &resource)
             .await
             .unwrap();
-        assert!(!denied, "Deny condition should fire for external IP");
+        assert!(
+            !denied.is_allowed(),
+            "Deny condition should fire for external IP"
+        );
 
         // Other actions still allowed
         let allowed = authz
             .authorize(&ctx, "iam:GetUser", &resource)
             .await
             .unwrap();
-        assert!(allowed, "iam:GetUser should still be allowed");
+        assert!(allowed.is_allowed(), "iam:GetUser should still be allowed");
     }
 
     // ========== Permissions boundary tests (P2.3) ==========
@@ -1320,14 +1376,20 @@ mod tests {
             .authorize(&ctx, "iam:GetUser", &resource)
             .await
             .unwrap();
-        assert!(allowed, "iam:GetUser should be allowed (within boundary)");
+        assert!(
+            allowed.is_allowed(),
+            "iam:GetUser should be allowed (within boundary)"
+        );
 
         // iam:ListUsers is in boundary → allowed
         let allowed = authz
             .authorize(&ctx, "iam:ListUsers", &resource)
             .await
             .unwrap();
-        assert!(allowed, "iam:ListUsers should be allowed (within boundary)");
+        assert!(
+            allowed.is_allowed(),
+            "iam:ListUsers should be allowed (within boundary)"
+        );
 
         // iam:DeleteUser is NOT in boundary → denied despite policy allowing it
         let denied = authz
@@ -1335,7 +1397,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            !denied,
+            !denied.is_allowed(),
             "iam:DeleteUser should be denied (outside boundary)"
         );
 
@@ -1345,7 +1407,7 @@ mod tests {
             .await
             .unwrap();
         assert!(
-            !denied,
+            !denied.is_allowed(),
             "iam:CreateUser should be denied (outside boundary)"
         );
     }
@@ -1371,7 +1433,7 @@ mod tests {
             .authorize(&ctx, "iam:DeleteUser", &resource)
             .await
             .unwrap();
-        assert!(allowed, "No boundary → full access per policy");
+        assert!(allowed.is_allowed(), "No boundary → full access per policy");
     }
 
     #[tokio::test]
@@ -1404,7 +1466,10 @@ mod tests {
             .authorize(&ctx, "iam:GetUser", &resource)
             .await
             .unwrap();
-        assert!(!denied, "Missing boundary policy → deny (fail closed)");
+        assert!(
+            !denied.is_allowed(),
+            "Missing boundary policy → deny (fail closed)"
+        );
     }
 
     #[tokio::test]
@@ -1459,13 +1524,294 @@ mod tests {
             .authorize(&ctx, "iam:DeleteUser", &resource)
             .await
             .unwrap();
-        assert!(!denied, "Explicit deny must win over boundary + allow");
+        assert!(
+            !denied.is_allowed(),
+            "Explicit deny must win over boundary + allow"
+        );
 
         // GetUser: allowed by policy AND boundary
         let allowed = authz
             .authorize(&ctx, "iam:GetUser", &resource)
             .await
             .unwrap();
-        assert!(allowed, "iam:GetUser should be allowed");
+        assert!(allowed.is_allowed(), "iam:GetUser should be allowed");
+    }
+
+    // ─── #100: the decision names what decided ────────────────────
+
+    #[tokio::test]
+    async fn an_allow_names_the_statement_that_granted_it() {
+        let ctx = test_context();
+        let store = setup_store_with_user(&ctx).await;
+        store
+            .write()
+            .await
+            .put_user_policy(
+                "alice",
+                "AllowReads",
+                r#"{"Version":"2012-10-17","Statement":[{"Sid":"ReadAnything","Effect":"Allow","Action":["iam:GetUser"],"Resource":["*"]}]}"#
+                    .to_string(),
+            )
+            .await
+            .unwrap();
+
+        let authz = AuthorizationService::new(store);
+        let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
+        let decision = authz
+            .authorize(&ctx, "iam:GetUser", &resource)
+            .await
+            .unwrap();
+
+        let Decision::Allow(AllowReason::Statements(refs)) = &decision else {
+            panic!("expected a statement-backed allow, got {decision:?}");
+        };
+        assert_eq!(refs.first().sid.as_deref(), Some("ReadAnything"));
+        assert_eq!(
+            refs.first().policy,
+            PolicySource::UserInline {
+                name: "AllowReads".to_string()
+            }
+        );
+        // And it renders into something an audit log can keep verbatim.
+        assert!(decision.to_string().contains("ReadAnything"));
+    }
+
+    #[tokio::test]
+    async fn a_deny_reports_every_source_that_denied_not_just_one() {
+        // Two independent denials — a group policy and a user policy. An
+        // auditor needs both; reporting only the first would hide one.
+        let ctx = test_context();
+        let store = setup_store_with_user(&ctx).await;
+        {
+            let mut s = store.write().await;
+            let group = group_builder::build_group("blocked".to_string(), None, &ctx).unwrap();
+            s.create_group(group).await.unwrap();
+            s.add_user_to_group("blocked", "alice").await.unwrap();
+            s.put_group_policy("blocked", "GroupDeny", deny_policy_json(&["iam:*"], &["*"]))
+                .await
+                .unwrap();
+            s.put_user_policy("alice", "UserDeny", deny_policy_json(&["iam:*"], &["*"]))
+                .await
+                .unwrap();
+        }
+
+        let authz = AuthorizationService::new(store);
+        let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
+        let decision = authz
+            .authorize(&ctx, "iam:GetUser", &resource)
+            .await
+            .unwrap();
+
+        let Decision::Deny(DenyReason::Statements(refs)) = &decision else {
+            panic!("expected statement-backed deny, got {decision:?}");
+        };
+        assert_eq!(refs.len(), 2, "both denials must be reported");
+        // Canonical order: the user's own policy before the group's, whatever
+        // order the store returned them in.
+        assert!(matches!(refs[0].policy, PolicySource::UserInline { .. }));
+        assert!(matches!(refs[1].policy, PolicySource::GroupInline { .. }));
+    }
+
+    #[tokio::test]
+    async fn nothing_matching_is_distinguishable_from_an_explicit_deny() {
+        let ctx = test_context();
+        let store = setup_store_with_user(&ctx).await;
+        let authz = AuthorizationService::new(store);
+        let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
+
+        // The distinction a bool could not carry: refused because a rule says
+        // so, versus refused because no rule applies.
+        assert_eq!(
+            authz
+                .authorize(&ctx, "iam:GetUser", &resource)
+                .await
+                .unwrap(),
+            Decision::Deny(DenyReason::NoMatch)
+        );
+    }
+
+    #[tokio::test]
+    async fn root_is_allowed_without_consulting_any_policy() {
+        let ctx = WamiContext::builder()
+            .instance_id("999")
+            .tenant_path(TenantPath::single(12345678))
+            .caller_arn(
+                "arn:wami:iam:12345678:wami:999:user/root"
+                    .parse::<Arn>()
+                    .unwrap(),
+            )
+            .is_root(true)
+            .build()
+            .unwrap();
+
+        let store = Arc::new(RwLock::new(InMemoryWamiStore::default()));
+        let authz = AuthorizationService::new(store);
+        let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
+
+        assert_eq!(
+            authz
+                .authorize(&ctx, "iam:DeleteUser", &resource)
+                .await
+                .unwrap(),
+            Decision::Allow(AllowReason::RootBypass)
+        );
+    }
+
+    // ─── boundary: two refusals, two different fixes ──────────────
+
+    async fn alice_with_boundary(
+        ctx: &WamiContext,
+        boundary: &str,
+    ) -> Arc<RwLock<InMemoryWamiStore>> {
+        let store = setup_store_with_user(ctx).await;
+        let mut s = store.write().await;
+        s.put_user_policy("alice", "AllowAll", allow_policy_json(&["iam:*"], &["*"]))
+            .await
+            .unwrap();
+        let policy = policy_builder::build_policy(
+            "Boundary".to_string(),
+            boundary.to_string(),
+            None,
+            None,
+            None,
+            ctx,
+        )
+        .unwrap();
+        let arn = policy.arn.clone();
+        s.create_policy(policy).await.unwrap();
+        let mut alice = s.get_user("alice").await.unwrap().unwrap();
+        alice.permissions_boundary = Some(arn);
+        s.update_user(alice).await.unwrap();
+        drop(s);
+        store
+    }
+
+    #[tokio::test]
+    async fn a_boundary_that_does_not_cover_the_action_says_so() {
+        let ctx = test_context();
+        // Allows something else entirely — the action is simply not covered.
+        let store = alice_with_boundary(&ctx, &allow_policy_json(&["s3:*"], &["*"])).await;
+        let authz = AuthorizationService::new(store);
+        let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
+
+        let decision = authz
+            .authorize(&ctx, "iam:GetUser", &resource)
+            .await
+            .unwrap();
+        let Decision::Deny(DenyReason::BoundaryRestricted {
+            allowed_by,
+            denied_by,
+            ..
+        }) = &decision
+        else {
+            panic!("expected boundary restriction, got {decision:?}");
+        };
+        assert!(
+            denied_by.is_empty(),
+            "no explicit deny — the fix is to widen the boundary"
+        );
+        assert!(!allowed_by.is_empty(), "identity policy did allow it");
+        assert!(decision.to_string().contains("does not cover"));
+    }
+
+    #[tokio::test]
+    async fn a_boundary_that_explicitly_denies_names_the_statement() {
+        let ctx = test_context();
+        let store = alice_with_boundary(&ctx, &deny_policy_json(&["iam:*"], &["*"])).await;
+        let authz = AuthorizationService::new(store);
+        let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
+
+        let decision = authz
+            .authorize(&ctx, "iam:GetUser", &resource)
+            .await
+            .unwrap();
+        let Decision::Deny(DenyReason::BoundaryRestricted { denied_by, .. }) = &decision else {
+            panic!("expected boundary restriction, got {decision:?}");
+        };
+        // The opposite remedy from the previous test: remove this statement.
+        assert_eq!(denied_by.len(), 1);
+        assert!(matches!(
+            denied_by[0].policy,
+            PolicySource::PermissionsBoundary { .. }
+        ));
+        assert!(decision.to_string().contains("refuses this action"));
+    }
+
+    // ─── #120: an unreadable policy is an error, not a silent allow ──
+
+    #[tokio::test]
+    async fn a_malformed_deny_no_longer_disappears() {
+        // Written straight to the store, as a third-party backend or a
+        // pre-fix row would be — the service layer now rejects this on write.
+        let ctx = test_context();
+        let store = setup_store_with_user(&ctx).await;
+        {
+            let mut s = store.write().await;
+            s.put_user_policy("alice", "Allow", allow_policy_json(&["iam:*"], &["*"]))
+                .await
+                .unwrap();
+            s.put_user_policy(
+                "alice",
+                "BrokenDeny",
+                // "Actions" instead of "Action" — valid JSON, invalid policy.
+                r#"{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Actions":["iam:*"],"Resource":["*"]}]}"#
+                    .to_string(),
+            )
+            .await
+            .unwrap();
+        }
+
+        let authz = AuthorizationService::new(store);
+        let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
+        let err = authz
+            .authorize(&ctx, "iam:GetUser", &resource)
+            .await
+            .expect_err("a policy that cannot be read must not yield a decision");
+
+        // Before the fix this returned Ok(true): the Deny parsed to nothing and
+        // the Allow won.
+        assert!(matches!(err, AmiError::UnreadablePolicy { .. }), "{err:?}");
+        assert!(err.to_string().contains("BrokenDeny"));
+    }
+
+    #[tokio::test]
+    async fn an_unreadable_boundary_is_reported_as_the_boundary() {
+        // The second parsing path. It must name the boundary, not leave the
+        // operator guessing which of the two documents failed.
+        let ctx = test_context();
+        let store = alice_with_boundary(&ctx, r#"{"Version":"2012-10-17"}"#).await;
+        let authz = AuthorizationService::new(store);
+        let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
+
+        let err = authz
+            .authorize(&ctx, "iam:GetUser", &resource)
+            .await
+            .expect_err("an unreadable boundary must not be treated as absent");
+        assert!(matches!(err, AmiError::UnreadablePolicy { .. }), "{err:?}");
+        assert!(err.to_string().contains("permissions boundary"));
+    }
+
+    #[tokio::test]
+    async fn a_malformed_policy_is_refused_on_write() {
+        // The other half of the fix: stop it entering the store at all.
+        use crate::service::policies::inline::InlinePolicyService;
+        use crate::wami::policies::inline::PutUserPolicyRequest;
+
+        let ctx = test_context();
+        let store = setup_store_with_user(&ctx).await;
+        let service = InlinePolicyService::new(store);
+
+        let err = service
+            .put_user_policy(
+                &ctx,
+                PutUserPolicyRequest {
+                    user_name: "alice".to_string(),
+                    policy_name: "BrokenDeny".to_string(),
+                    policy_document: r#"{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Actions":["iam:*"],"Resource":["*"]}]}"#.to_string(),
+                },
+            )
+            .await
+            .expect_err("valid JSON that is not a valid policy must be refused");
+        assert!(matches!(err, AmiError::InvalidParameter { .. }), "{err:?}");
     }
 }

--- a/crates/wami/src/service/auth/authorizer.rs
+++ b/crates/wami/src/service/auth/authorizer.rs
@@ -7,7 +7,9 @@ use async_trait::async_trait;
 use std::sync::Arc;
 use wami_core::arn::WamiArn;
 use wami_core::context::WamiContext;
-use wami_core::error::Result;
+use wami_core::error::{AmiError, Result};
+
+use super::decision::Decision;
 
 /// Object-safe authorization interface.
 ///
@@ -16,23 +18,50 @@ use wami_core::error::Result;
 /// (backward compatibility with existing callers).
 #[async_trait]
 pub trait Authorizer: Send + Sync {
-    /// Check if `context` is allowed to perform `action` on `resource_arn`.
+    /// Decide whether `context` may perform `action` on `resource_arn`.
     ///
-    /// Returns `Ok(true)` if allowed, `Ok(false)` if denied.
+    /// Returns the verdict *and what produced it*, so a caller can write an
+    /// audit line naming the statement that decided, and tell a refused user
+    /// what they lack.
+    ///
+    /// # Errors
+    ///
+    /// [`AmiError::UnreadablePolicy`] when a policy document cannot be parsed.
+    /// That is deliberately not a denial: an unreadable policy might have held
+    /// a deny, so no decision can honestly be made from it.
+    ///
+    /// [`AmiError::UnreadablePolicy`]: wami_core::error::AmiError::UnreadablePolicy
     async fn authorize(
         &self,
         context: &WamiContext,
         action: &str,
         resource_arn: &WamiArn,
-    ) -> Result<bool>;
+    ) -> Result<Decision>;
 
-    /// Like [`Authorizer::authorize`], but returns `Err(AccessDenied)` instead of `Ok(false)`.
+    /// Like [`Authorizer::authorize`], but returns `Err(AccessDenied)` on refusal.
+    ///
+    /// Implemented in terms of `authorize`, so implementors only supply the
+    /// latter — and the two cannot drift apart. The error message quotes the
+    /// [`Decision`], which is why overriding this is rarely worth it.
     async fn check_or_deny(
         &self,
         context: &WamiContext,
         action: &str,
         resource_arn: &WamiArn,
-    ) -> Result<()>;
+    ) -> Result<()> {
+        match self.authorize(context, action, resource_arn).await? {
+            Decision::Allow(_) => Ok(()),
+            denied => Err(AmiError::AccessDenied {
+                message: format!(
+                    "{} is not authorized to perform {} on {}: {}",
+                    context.caller_arn(),
+                    action,
+                    resource_arn,
+                    denied
+                ),
+            }),
+        }
+    }
 }
 
 /// Helper: build a WAMI ARN for an IAM resource from the caller's context.
@@ -76,17 +105,8 @@ mod impl_for_authz_service {
             context: &WamiContext,
             action: &str,
             resource_arn: &WamiArn,
-        ) -> Result<bool> {
+        ) -> Result<Decision> {
             AuthorizationService::authorize(self, context, action, resource_arn).await
-        }
-
-        async fn check_or_deny(
-            &self,
-            context: &WamiContext,
-            action: &str,
-            resource_arn: &WamiArn,
-        ) -> Result<()> {
-            AuthorizationService::check_or_deny(self, context, action, resource_arn).await
         }
     }
 
@@ -103,6 +123,7 @@ pub use impl_for_authz_service::into_authorizer;
 
 #[cfg(test)]
 mod tests {
+    use super::super::decision::{AllowReason, DenyReason};
     use super::*;
     use crate::service::auth::authorization::AuthorizationService;
     use crate::store::memory::InMemoryWamiStore;
@@ -210,7 +231,12 @@ mod tests {
             .authorize(&ctx, "iam:GetUser", &resource)
             .await
             .unwrap();
-        assert!(allowed);
+        assert!(allowed.is_allowed());
+        // The grant names what granted it — that is the point of the change.
+        assert!(matches!(
+            allowed,
+            Decision::Allow(AllowReason::Statements(_))
+        ));
     }
 
     #[tokio::test]
@@ -228,7 +254,8 @@ mod tests {
             .authorize(&ctx, "iam:GetUser", &resource)
             .await
             .unwrap();
-        assert!(!allowed);
+        // Nothing matched, so there is no statement to name.
+        assert_eq!(allowed, Decision::Deny(DenyReason::NoMatch));
     }
 
     #[tokio::test]

--- a/crates/wami/src/service/auth/decision.rs
+++ b/crates/wami/src/service/auth/decision.rs
@@ -1,0 +1,371 @@
+//! What an authorization decision was, and what decided it.
+//!
+//! `authorize` used to return `bool`. A verdict cannot be audited and cannot be
+//! explained: a log line needs to name the statement that decided, and a denied
+//! user needs to be told what they lack. Neither is recoverable from `true` /
+//! `false`.
+//!
+//! The effect is carried by the variant rather than a separate field, so
+//! combinations the domain forbids — an `Allow` justified by a missing
+//! permissions boundary, say — cannot be constructed at all.
+
+use std::fmt;
+use std::ops::Deref;
+
+/// A list that cannot be empty.
+///
+/// [`Decision`] is public API, so "this list always has at least one element"
+/// is worth making unrepresentable rather than documenting. Small enough to own
+/// outright — it would be a poor trade to take a dependency for it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NonEmpty<T>(Vec<T>);
+
+impl<T> NonEmpty<T> {
+    /// Wrap `items`, or return them untouched if there is nothing to wrap.
+    ///
+    /// The rejected input is handed back rather than dropped: callers that hit
+    /// the empty case usually need the allocation to build an error.
+    pub fn new(items: Vec<T>) -> Result<Self, Vec<T>> {
+        if items.is_empty() {
+            Err(items)
+        } else {
+            Ok(Self(items))
+        }
+    }
+
+    /// A list of exactly one.
+    pub fn one(item: T) -> Self {
+        Self(vec![item])
+    }
+
+    /// The first element. Total, by construction.
+    pub fn first(&self) -> &T {
+        &self.0[0]
+    }
+
+    /// Give up the guarantee and take the elements.
+    pub fn into_vec(self) -> Vec<T> {
+        self.0
+    }
+}
+
+impl<T> Deref for NonEmpty<T> {
+    type Target = [T];
+
+    fn deref(&self) -> &[T] {
+        &self.0
+    }
+}
+
+impl<T> IntoIterator for NonEmpty<T> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, T> IntoIterator for &'a NonEmpty<T> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+/// Where a statement came from.
+///
+/// The declaration order is load-bearing: it is the collection order of
+/// [`AuthorizationService::authorize`], and the derived [`Ord`] is what makes
+/// the reported sources deterministic regardless of what order the store
+/// happened to return rows in.
+///
+/// [`AuthorizationService::authorize`]: crate::service::auth::AuthorizationService::authorize
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub enum PolicySource {
+    /// A managed policy attached to the user.
+    UserManaged {
+        /// The policy's ARN.
+        arn: String,
+    },
+    /// A policy inlined on the user.
+    UserInline {
+        /// The policy's name.
+        name: String,
+    },
+    /// A managed policy attached to one of the user's groups.
+    GroupManaged {
+        /// The group holding the attachment.
+        group: String,
+        /// The policy's ARN.
+        arn: String,
+    },
+    /// A policy inlined on one of the user's groups.
+    GroupInline {
+        /// The group holding the policy.
+        group: String,
+        /// The policy's name.
+        name: String,
+    },
+    /// A managed policy attached to the assumed role.
+    RoleManaged {
+        /// The assumed role.
+        role: String,
+        /// The policy's ARN.
+        arn: String,
+    },
+    /// A policy inlined on the assumed role.
+    RoleInline {
+        /// The assumed role.
+        role: String,
+        /// The policy's name.
+        name: String,
+    },
+    /// The permissions boundary itself.
+    ///
+    /// Not a source of permissions — a ceiling on them. It appears here so
+    /// [`AmiError::UnreadablePolicy`] can say *which* document failed to parse,
+    /// the boundary being read on a different path from the identity policies.
+    ///
+    /// [`AmiError::UnreadablePolicy`]: wami_core::error::AmiError::UnreadablePolicy
+    PermissionsBoundary {
+        /// The boundary policy's ARN.
+        arn: String,
+    },
+}
+
+impl fmt::Display for PolicySource {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UserManaged { arn } => write!(f, "user managed policy {arn}"),
+            Self::UserInline { name } => write!(f, "user inline policy {name}"),
+            Self::GroupManaged { group, arn } => {
+                write!(f, "managed policy {arn} of group {group}")
+            }
+            Self::GroupInline { group, name } => {
+                write!(f, "inline policy {name} of group {group}")
+            }
+            Self::RoleManaged { role, arn } => write!(f, "managed policy {arn} of role {role}"),
+            Self::RoleInline { role, name } => write!(f, "inline policy {name} of role {role}"),
+            Self::PermissionsBoundary { arn } => write!(f, "permissions boundary {arn}"),
+        }
+    }
+}
+
+/// The statement that decided, and the policy it came from.
+///
+/// One per contributing source — the *decisive* statement of that document, not
+/// every statement it contains: evaluation stops at the first match within a
+/// document, deny before allow.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct StatementRef {
+    /// Which policy this statement lives in.
+    pub policy: PolicySource,
+    /// The statement's `Sid`, when the author supplied one.
+    pub sid: Option<String>,
+    /// Position in the document.
+    ///
+    /// A fallback for statements with no `Sid`, and deliberately not a stable
+    /// identifier: rewriting a policy renumbers it. Fine for reproducing a
+    /// decision now, not for pinning one in a durable log.
+    pub index: usize,
+}
+
+impl fmt::Display for StatementRef {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match &self.sid {
+            Some(sid) => write!(f, "statement `{sid}` of {}", self.policy),
+            None => write!(f, "statement #{} of {}", self.index, self.policy),
+        }
+    }
+}
+
+/// Why access was granted.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AllowReason {
+    /// The caller is root, so no policy was consulted at all.
+    ///
+    /// Root bypasses the permissions boundary too, as it does in AWS.
+    RootBypass,
+    /// Statements that allowed the action, in collection order.
+    Statements(NonEmpty<StatementRef>),
+}
+
+/// Why access was refused.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DenyReason {
+    /// Nothing matched.
+    ///
+    /// An implicit denial: there is no statement to name, because none applied.
+    /// The permissions boundary is not consulted on this path — it can only
+    /// narrow permissions, never grant them, so with nothing to narrow it
+    /// cannot change the outcome.
+    NoMatch,
+    /// Statements that explicitly denied the action, in collection order.
+    Statements(NonEmpty<StatementRef>),
+    /// The identity policies allowed it and the permissions boundary did not.
+    BoundaryRestricted {
+        /// The boundary that cut the action off.
+        arn: String,
+        /// What would otherwise have allowed it.
+        allowed_by: NonEmpty<StatementRef>,
+        /// Explicit denials inside the boundary.
+        ///
+        /// Empty means the boundary simply does not cover the action — the fix
+        /// is to widen it. Non-empty means it refuses the action outright — the
+        /// fix is to remove those statements. Opposite remedies, so the
+        /// distinction has to survive into the log.
+        denied_by: Vec<StatementRef>,
+    },
+    /// The user references a permissions boundary that the store does not hold.
+    ///
+    /// Fails closed: a ceiling that cannot be read cannot be honoured.
+    BoundaryMissing {
+        /// The ARN that resolved to nothing.
+        arn: String,
+    },
+}
+
+/// An authorization decision, and what produced it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Decision {
+    /// The action is permitted.
+    Allow(AllowReason),
+    /// The action is refused.
+    Deny(DenyReason),
+}
+
+impl Decision {
+    /// Whether the action is permitted.
+    pub fn is_allowed(&self) -> bool {
+        matches!(self, Self::Allow(_))
+    }
+}
+
+impl fmt::Display for Decision {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Allow(AllowReason::RootBypass) => write!(f, "allowed: caller is root"),
+            Self::Allow(AllowReason::Statements(refs)) => {
+                write!(f, "allowed by {}", refs.first())
+            }
+            Self::Deny(DenyReason::NoMatch) => {
+                write!(f, "denied: no statement matches this action and resource")
+            }
+            Self::Deny(DenyReason::Statements(refs)) => write!(f, "denied by {}", refs.first()),
+            Self::Deny(DenyReason::BoundaryRestricted { arn, denied_by, .. }) => {
+                match denied_by.first() {
+                    Some(statement) => write!(
+                        f,
+                        "denied by {statement}: permissions boundary {arn} refuses this action"
+                    ),
+                    None => write!(
+                        f,
+                        "denied: permissions boundary {arn} does not cover this action"
+                    ),
+                }
+            }
+            Self::Deny(DenyReason::BoundaryMissing { arn }) => {
+                write!(f, "denied: permissions boundary {arn} was not found")
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn statement(policy: PolicySource, sid: Option<&str>) -> StatementRef {
+        StatementRef {
+            policy,
+            sid: sid.map(str::to_string),
+            index: 0,
+        }
+    }
+
+    #[test]
+    fn an_empty_list_cannot_become_non_empty() {
+        assert!(NonEmpty::<u8>::new(vec![]).is_err());
+        assert_eq!(NonEmpty::new(vec![1, 2]).unwrap().first(), &1);
+    }
+
+    #[test]
+    fn sources_sort_in_evaluation_order_not_store_order() {
+        // The whole point of the canonical sort: the store guarantees no
+        // ordering, so two backends returning the same policies in different
+        // orders must still produce the same audit line.
+        let mut shuffled = vec![
+            PolicySource::RoleInline {
+                role: "r".into(),
+                name: "n".into(),
+            },
+            PolicySource::UserManaged { arn: "a".into() },
+            PolicySource::GroupInline {
+                group: "g".into(),
+                name: "n".into(),
+            },
+            PolicySource::UserInline { name: "n".into() },
+        ];
+        shuffled.sort();
+
+        assert_eq!(
+            shuffled,
+            vec![
+                PolicySource::UserManaged { arn: "a".into() },
+                PolicySource::UserInline { name: "n".into() },
+                PolicySource::GroupInline {
+                    group: "g".into(),
+                    name: "n".into()
+                },
+                PolicySource::RoleInline {
+                    role: "r".into(),
+                    name: "n".into()
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn a_denied_user_is_told_what_to_fix() {
+        // The two boundary cases call for opposite remedies, so they must not
+        // read the same.
+        let allowed = NonEmpty::one(statement(
+            PolicySource::UserManaged { arn: "p".into() },
+            Some("AllowAll"),
+        ));
+
+        let uncovered = Decision::Deny(DenyReason::BoundaryRestricted {
+            arn: "b".into(),
+            allowed_by: allowed.clone(),
+            denied_by: vec![],
+        });
+        assert!(uncovered.to_string().contains("does not cover"));
+
+        let refused = Decision::Deny(DenyReason::BoundaryRestricted {
+            arn: "b".into(),
+            allowed_by: allowed,
+            denied_by: vec![statement(
+                PolicySource::PermissionsBoundary { arn: "b".into() },
+                Some("DenyWrites"),
+            )],
+        });
+        assert!(refused.to_string().contains("DenyWrites"));
+        assert!(refused.to_string().contains("refuses this action"));
+    }
+
+    #[test]
+    fn a_statement_without_a_sid_falls_back_to_its_index() {
+        let named = statement(PolicySource::UserInline { name: "p".into() }, Some("Sid1"));
+        assert!(named.to_string().contains("`Sid1`"));
+
+        let anonymous = StatementRef {
+            policy: PolicySource::UserInline { name: "p".into() },
+            sid: None,
+            index: 3,
+        };
+        assert!(anonymous.to_string().contains("#3"));
+    }
+}

--- a/crates/wami/src/service/auth/decision.rs
+++ b/crates/wami/src/service/auth/decision.rs
@@ -368,4 +368,97 @@ mod tests {
         };
         assert!(anonymous.to_string().contains("#3"));
     }
+
+    #[test]
+    fn every_source_renders_for_an_audit_line() {
+        // Display is the audit surface: an unrendered variant is a log entry
+        // that says nothing on the day it is read.
+        let cases = [
+            (
+                PolicySource::UserManaged { arn: "a".into() },
+                "user managed policy a",
+            ),
+            (
+                PolicySource::UserInline { name: "n".into() },
+                "user inline policy n",
+            ),
+            (
+                PolicySource::GroupManaged {
+                    group: "g".into(),
+                    arn: "a".into(),
+                },
+                "managed policy a of group g",
+            ),
+            (
+                PolicySource::GroupInline {
+                    group: "g".into(),
+                    name: "n".into(),
+                },
+                "inline policy n of group g",
+            ),
+            (
+                PolicySource::RoleManaged {
+                    role: "r".into(),
+                    arn: "a".into(),
+                },
+                "managed policy a of role r",
+            ),
+            (
+                PolicySource::RoleInline {
+                    role: "r".into(),
+                    name: "n".into(),
+                },
+                "inline policy n of role r",
+            ),
+            (
+                PolicySource::PermissionsBoundary { arn: "b".into() },
+                "permissions boundary b",
+            ),
+        ];
+        for (source, expected) in cases {
+            assert_eq!(source.to_string(), expected);
+        }
+    }
+
+    #[test]
+    fn every_decision_renders_for_an_audit_line() {
+        let one = NonEmpty::one(statement(
+            PolicySource::UserInline { name: "p".into() },
+            Some("S"),
+        ));
+
+        assert!(Decision::Allow(AllowReason::RootBypass)
+            .to_string()
+            .contains("caller is root"));
+        assert!(Decision::Allow(AllowReason::Statements(one.clone()))
+            .to_string()
+            .starts_with("allowed by"));
+        assert!(Decision::Deny(DenyReason::NoMatch)
+            .to_string()
+            .contains("no statement matches"));
+        assert!(Decision::Deny(DenyReason::Statements(one))
+            .to_string()
+            .starts_with("denied by"));
+        assert!(
+            Decision::Deny(DenyReason::BoundaryMissing { arn: "b".into() })
+                .to_string()
+                .contains("was not found")
+        );
+    }
+
+    #[test]
+    fn a_non_empty_list_behaves_like_the_slice_it_wraps() {
+        let items = NonEmpty::new(vec![1, 2, 3]).unwrap();
+        assert_eq!(items.len(), 3);
+        assert_eq!(items.iter().sum::<i32>(), 6);
+        assert_eq!((&items).into_iter().copied().max(), Some(3));
+        assert_eq!(items.clone().into_iter().count(), 3);
+        assert_eq!(items.into_vec(), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn is_allowed_matches_the_variant() {
+        assert!(Decision::Allow(AllowReason::RootBypass).is_allowed());
+        assert!(!Decision::Deny(DenyReason::NoMatch).is_allowed());
+    }
 }

--- a/crates/wami/src/service/auth/mod.rs
+++ b/crates/wami/src/service/auth/mod.rs
@@ -41,11 +41,10 @@
 //!     let authz_service = AuthorizationService::new(store.clone());
 //!     let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/alice".parse()?;
 //!     
-//!     if authz_service.authorize(&context, "iam:GetUser", &resource).await? {
-//!         println!("Access granted");
-//!     } else {
-//!         println!("Access denied");
-//!     }
+//!     let decision = authz_service
+//!         .authorize(&context, "iam:GetUser", &resource)
+//!         .await?;
+//!     println!("{decision}");
 //!
 //!     Ok(())
 //! }
@@ -54,11 +53,13 @@
 pub mod authentication;
 pub mod authorization;
 pub mod authorizer;
+pub mod decision;
 pub mod policy_evaluator;
 
 pub use authentication::{hash_secret, verify_secret, AuthenticationService};
 pub use authorization::AuthorizationService;
 pub use authorizer::{iam_resource_arn, into_authorizer, Authorizer};
+pub use decision::{AllowReason, Decision, DenyReason, NonEmpty, PolicySource, StatementRef};
 pub use policy_evaluator::{
     build_condition_context, evaluate_policy_document, matches_action, matches_condition,
     matches_resource, parse_policy_doc, PolicyEffect,

--- a/crates/wami/src/service/auth/policy_evaluator.rs
+++ b/crates/wami/src/service/auth/policy_evaluator.rs
@@ -17,7 +17,10 @@ use wami_condition::{
 use wami_core::arn::matching::{glob_match, matches_arn_pattern, MatchContext};
 use wami_core::arn::WamiArn;
 use wami_core::context::WamiContext;
+use wami_core::error::{AmiError, Result};
 use wami_core::types::{PolicyDocument, PolicyStatement};
+
+use super::decision::PolicySource;
 
 /// Policy evaluation result for a single policy document.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -30,18 +33,32 @@ pub enum PolicyEffect {
     NoMatch,
 }
 
+/// The statement that decided a document, and what it decided.
+///
+/// One per document, not one per matching statement: evaluation stops at the
+/// first match, denies before allows, so a document has exactly one decisive
+/// statement or none at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StatementHit {
+    /// What the statement decided — never `NoMatch`.
+    pub effect: PolicyEffect,
+    /// The statement's `Sid`, if it has one.
+    pub sid: Option<String>,
+    /// Its position in the document.
+    pub index: usize,
+}
+
 /// Evaluate a single policy document against an action and resource.
 ///
-/// Returns:
-/// - `Allow` if the policy explicitly allows the action
-/// - `Deny` if the policy explicitly denies the action
-/// - `NoMatch` if the policy doesn't apply
+/// Returns the statement that decided, or `None` when the document does not
+/// apply. Which statement decided is what lets a caller write an audit line
+/// naming it — the effect alone cannot be traced back to anything.
 pub fn evaluate_policy_document(
     policy: &PolicyDocument,
     action: &str,
     resource_arn: &WamiArn,
     context: &WamiContext,
-) -> PolicyEffect {
+) -> Option<StatementHit> {
     let resource_str = resource_arn.to_string();
     let match_ctx = MatchContext {
         tenant: Some(context.tenant_path().as_string()),
@@ -50,29 +67,33 @@ pub fn evaluate_policy_document(
     };
     let cond_ctx = build_condition_context(context, resource_arn);
 
-    // First check for explicit denies (deny overrides allow)
-    for statement in &policy.statement {
-        if statement.effect.to_lowercase() == "deny"
-            && matches_action(&statement.action, action)
+    let hit = |effect: PolicyEffect, index: usize, statement: &PolicyStatement| StatementHit {
+        effect,
+        sid: statement.sid.clone(),
+        index,
+    };
+
+    let applies = |statement: &PolicyStatement| {
+        matches_action(&statement.action, action)
             && matches_resource(&statement.resource, &resource_str, &match_ctx)
             && matches_condition(statement, &cond_ctx)
-        {
-            return PolicyEffect::Deny;
+    };
+
+    // Explicit denies first — a deny anywhere in the document wins over an
+    // allow later in it.
+    for (index, statement) in policy.statement.iter().enumerate() {
+        if statement.effect.to_lowercase() == "deny" && applies(statement) {
+            return Some(hit(PolicyEffect::Deny, index, statement));
         }
     }
 
-    // Then check for allows
-    for statement in &policy.statement {
-        if statement.effect.to_lowercase() == "allow"
-            && matches_action(&statement.action, action)
-            && matches_resource(&statement.resource, &resource_str, &match_ctx)
-            && matches_condition(statement, &cond_ctx)
-        {
-            return PolicyEffect::Allow;
+    for (index, statement) in policy.statement.iter().enumerate() {
+        if statement.effect.to_lowercase() == "allow" && applies(statement) {
+            return Some(hit(PolicyEffect::Allow, index, statement));
         }
     }
 
-    PolicyEffect::NoMatch
+    None
 }
 
 /// Check if an action matches any of the policy action patterns.
@@ -158,11 +179,24 @@ pub fn matches_condition(statement: &PolicyStatement, cond_ctx: &ConditionContex
     evaluate_condition_block(&block, cond_ctx).unwrap_or_default()
 }
 
-/// Parse a policy document JSON string, returning an empty doc on error.
-pub fn parse_policy_doc(json: &str) -> PolicyDocument {
-    serde_json::from_str(json).unwrap_or_else(|_| PolicyDocument {
-        version: "2012-10-17".to_string(),
-        statement: vec![],
+/// Parse a policy document, refusing to guess when it cannot be read.
+///
+/// This used to swallow the error and hand back an empty document. For an
+/// `Allow` that was merely useless; for a `Deny` it was a fail-open — the
+/// statement meant to block the action stopped existing, and any `Allow` from
+/// another source won. One typo was enough:
+///
+/// ```text
+/// {"Effect":"Deny","Actions":["iam:*"],"Resource":["*"]}
+///                   ^ plural — valid JSON, not a PolicyStatement
+/// ```
+///
+/// Refusing to decide is the only safe answer: a document that cannot be read
+/// might have contained a deny, and there is no way to know.
+pub fn parse_policy_doc(json: &str, policy: &PolicySource) -> Result<PolicyDocument> {
+    serde_json::from_str(json).map_err(|e| AmiError::UnreadablePolicy {
+        policy: policy.to_string(),
+        message: e.to_string(),
     })
 }
 
@@ -186,6 +220,7 @@ mod tests {
         PolicyDocument {
             version: "2012-10-17".to_string(),
             statement: vec![PolicyStatement {
+                sid: None,
                 effect: effect.to_string(),
                 action: actions.iter().map(|a| a.to_string()).collect(),
                 resource: resources.iter().map(|r| r.to_string()).collect(),
@@ -201,6 +236,7 @@ mod tests {
         condition: Option<serde_json::Value>,
     ) -> PolicyStatement {
         PolicyStatement {
+            sid: None,
             effect: effect.to_string(),
             action: actions.iter().map(|a| a.to_string()).collect(),
             resource: resources.iter().map(|r| r.to_string()).collect(),
@@ -354,25 +390,59 @@ mod tests {
 
     // ─── parse_policy_doc ─────────────────────────────────────
 
+    fn a_policy() -> PolicySource {
+        PolicySource::UserInline {
+            name: "p".to_string(),
+        }
+    }
+
     #[test]
     fn parse_policy_doc_valid() {
         let json = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["iam:GetUser"],"Resource":["*"]}]}"#;
-        let doc = parse_policy_doc(json);
+        let doc = parse_policy_doc(json, &a_policy()).unwrap();
         assert_eq!(doc.statement.len(), 1);
         assert_eq!(doc.statement[0].effect, "Allow");
     }
 
     #[test]
-    fn parse_policy_doc_invalid_returns_empty() {
-        let doc = parse_policy_doc("not json at all");
-        assert_eq!(doc.version, "2012-10-17");
-        assert!(doc.statement.is_empty());
+    fn a_sid_survives_a_round_trip() {
+        let json = r#"{"Version":"2012-10-17","Statement":[{"Sid":"AllowReads","Effect":"Allow","Action":["iam:GetUser"],"Resource":["*"]}]}"#;
+        let doc = parse_policy_doc(json, &a_policy()).unwrap();
+        assert_eq!(doc.statement[0].sid.as_deref(), Some("AllowReads"));
+        // Documents without a Sid must not gain an empty one when written back.
+        let plain = parse_policy_doc(
+            r#"{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["a"],"Resource":["*"]}]}"#,
+            &a_policy(),
+        )
+        .unwrap();
+        assert!(!serde_json::to_string(&plain).unwrap().contains("Sid"));
     }
 
     #[test]
-    fn parse_policy_doc_empty_string() {
-        let doc = parse_policy_doc("");
-        assert!(doc.statement.is_empty());
+    fn an_unreadable_policy_refuses_to_parse_instead_of_returning_nothing() {
+        // The whole of #120: this used to yield an empty document, so a Deny
+        // written with a typo simply stopped existing and any Allow elsewhere
+        // won. Now it cannot be mistaken for a policy that permits nothing.
+        for bad in ["not json at all", "", r#"{"Version":"2012-10-17"}"#] {
+            let err = parse_policy_doc(bad, &a_policy()).unwrap_err();
+            assert!(
+                matches!(err, AmiError::UnreadablePolicy { .. }),
+                "{bad:?} gave {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn a_deny_with_a_typo_no_longer_vanishes() {
+        // Valid JSON, so it passes a `serde_json::Value` check, but not a
+        // PolicyStatement: "Actions" instead of "Action". One character.
+        let typo = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Actions":["iam:*"],"Resource":["*"]}]}"#;
+        assert!(serde_json::from_str::<serde_json::Value>(typo).is_ok());
+
+        let err = parse_policy_doc(typo, &a_policy()).unwrap_err();
+        assert!(matches!(err, AmiError::UnreadablePolicy { .. }));
+        // And the operator is told which policy to go fix.
+        assert!(err.to_string().contains("user inline policy p"));
     }
 
     // ─── evaluate_policy_document ─────────────────────────────
@@ -383,8 +453,8 @@ mod tests {
         let policy = make_policy("Allow", &["iam:GetUser"], &["*"]);
         let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
         assert_eq!(
-            evaluate_policy_document(&policy, "iam:GetUser", &resource, &ctx),
-            PolicyEffect::Allow
+            evaluate_policy_document(&policy, "iam:GetUser", &resource, &ctx).map(|hit| hit.effect),
+            Some(PolicyEffect::Allow)
         );
     }
 
@@ -400,8 +470,9 @@ mod tests {
         };
         let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
         assert_eq!(
-            evaluate_policy_document(&policy, "iam:DeleteUser", &resource, &ctx),
-            PolicyEffect::Deny
+            evaluate_policy_document(&policy, "iam:DeleteUser", &resource, &ctx)
+                .map(|hit| hit.effect),
+            Some(PolicyEffect::Deny)
         );
     }
 
@@ -410,10 +481,7 @@ mod tests {
         let ctx = make_context();
         let policy = make_policy("Allow", &["sts:AssumeRole"], &["*"]);
         let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
-        assert_eq!(
-            evaluate_policy_document(&policy, "iam:GetUser", &resource, &ctx),
-            PolicyEffect::NoMatch
-        );
+        assert!(evaluate_policy_document(&policy, "iam:GetUser", &resource, &ctx).is_none());
     }
 
     #[test]
@@ -422,8 +490,8 @@ mod tests {
         let policy = make_policy("Deny", &["iam:*"], &["*"]);
         let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
         assert_eq!(
-            evaluate_policy_document(&policy, "iam:GetUser", &resource, &ctx),
-            PolicyEffect::Deny
+            evaluate_policy_document(&policy, "iam:GetUser", &resource, &ctx).map(|hit| hit.effect),
+            Some(PolicyEffect::Deny)
         );
     }
 
@@ -435,10 +503,7 @@ mod tests {
             statement: vec![],
         };
         let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
-        assert_eq!(
-            evaluate_policy_document(&policy, "iam:GetUser", &resource, &ctx),
-            PolicyEffect::NoMatch
-        );
+        assert!(evaluate_policy_document(&policy, "iam:GetUser", &resource, &ctx).is_none());
     }
 
     #[test]
@@ -447,8 +512,9 @@ mod tests {
         let policy = make_policy("Allow", &["*"], &["*"]);
         let resource: WamiArn = "arn:wami:iam:12345678:wami:999:user/bob".parse().unwrap();
         assert_eq!(
-            evaluate_policy_document(&policy, "anything:Here", &resource, &ctx),
-            PolicyEffect::Allow
+            evaluate_policy_document(&policy, "anything:Here", &resource, &ctx)
+                .map(|hit| hit.effect),
+            Some(PolicyEffect::Allow)
         );
     }
 

--- a/crates/wami/src/service/credentials/access_key.rs
+++ b/crates/wami/src/service/credentials/access_key.rs
@@ -151,6 +151,7 @@ impl<S: AccessKeyStore> AccessKeyService<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::auth::decision::{Decision, DenyReason};
     use crate::store::memory::InMemoryWamiStore;
     use wami_core::arn::{TenantPath, WamiArn};
 
@@ -307,8 +308,8 @@ mod tests {
             _context: &WamiContext,
             _action: &str,
             _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(false)
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Deny(DenyReason::NoMatch))
         }
         async fn check_or_deny(
             &self,

--- a/crates/wami/src/service/credentials/access_key.rs
+++ b/crates/wami/src/service/credentials/access_key.rs
@@ -311,16 +311,6 @@ mod tests {
         ) -> wami_core::error::Result<Decision> {
             Ok(Decision::Deny(DenyReason::NoMatch))
         }
-        async fn check_or_deny(
-            &self,
-            _context: &WamiContext,
-            _action: &str,
-            _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Err(wami_core::error::AmiError::AccessDenied {
-                message: "denied by mock".to_string(),
-            })
-        }
     }
 
     #[tokio::test]

--- a/crates/wami/src/service/credentials/login_profile.rs
+++ b/crates/wami/src/service/credentials/login_profile.rs
@@ -267,16 +267,6 @@ mod tests {
         ) -> wami_core::error::Result<Decision> {
             Ok(Decision::Deny(DenyReason::NoMatch))
         }
-        async fn check_or_deny(
-            &self,
-            _context: &WamiContext,
-            _action: &str,
-            _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Err(wami_core::error::AmiError::AccessDenied {
-                message: "denied by mock".to_string(),
-            })
-        }
     }
 
     #[tokio::test]

--- a/crates/wami/src/service/credentials/login_profile.rs
+++ b/crates/wami/src/service/credentials/login_profile.rs
@@ -146,6 +146,7 @@ impl<S: LoginProfileStore> LoginProfileService<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::auth::decision::{Decision, DenyReason};
     use crate::store::memory::InMemoryWamiStore;
     use wami_core::arn::{TenantPath, WamiArn};
 
@@ -263,8 +264,8 @@ mod tests {
             _context: &WamiContext,
             _action: &str,
             _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(false)
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Deny(DenyReason::NoMatch))
         }
         async fn check_or_deny(
             &self,

--- a/crates/wami/src/service/credentials/mfa_device.rs
+++ b/crates/wami/src/service/credentials/mfa_device.rs
@@ -249,16 +249,6 @@ mod tests {
         ) -> wami_core::error::Result<Decision> {
             Ok(Decision::Deny(DenyReason::NoMatch))
         }
-        async fn check_or_deny(
-            &self,
-            _context: &WamiContext,
-            _action: &str,
-            _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Err(wami_core::error::AmiError::AccessDenied {
-                message: "denied by mock".to_string(),
-            })
-        }
     }
 
     #[tokio::test]

--- a/crates/wami/src/service/credentials/mfa_device.rs
+++ b/crates/wami/src/service/credentials/mfa_device.rs
@@ -136,6 +136,7 @@ impl<S: MfaDeviceStore> MfaDeviceService<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::auth::decision::{Decision, DenyReason};
     use crate::store::memory::InMemoryWamiStore;
     use wami_core::arn::{TenantPath, WamiArn};
 
@@ -245,8 +246,8 @@ mod tests {
             _context: &WamiContext,
             _action: &str,
             _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(false)
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Deny(DenyReason::NoMatch))
         }
         async fn check_or_deny(
             &self,

--- a/crates/wami/src/service/credentials/server_certificate.rs
+++ b/crates/wami/src/service/credentials/server_certificate.rs
@@ -195,6 +195,7 @@ impl<S: ServerCertificateStore> ServerCertificateService<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::auth::decision::{Decision, DenyReason};
     use crate::store::memory::InMemoryWamiStore;
 
     fn setup_service() -> ServerCertificateService<InMemoryWamiStore> {
@@ -395,8 +396,8 @@ mod tests {
             _context: &WamiContext,
             _action: &str,
             _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(false)
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Deny(DenyReason::NoMatch))
         }
         async fn check_or_deny(
             &self,

--- a/crates/wami/src/service/credentials/server_certificate.rs
+++ b/crates/wami/src/service/credentials/server_certificate.rs
@@ -399,16 +399,6 @@ mod tests {
         ) -> wami_core::error::Result<Decision> {
             Ok(Decision::Deny(DenyReason::NoMatch))
         }
-        async fn check_or_deny(
-            &self,
-            _context: &WamiContext,
-            _action: &str,
-            _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Err(wami_core::error::AmiError::AccessDenied {
-                message: "denied by mock".to_string(),
-            })
-        }
     }
 
     #[tokio::test]

--- a/crates/wami/src/service/credentials/service_credential.rs
+++ b/crates/wami/src/service/credentials/service_credential.rs
@@ -333,16 +333,6 @@ mod tests {
         ) -> wami_core::error::Result<Decision> {
             Ok(Decision::Deny(DenyReason::NoMatch))
         }
-        async fn check_or_deny(
-            &self,
-            _context: &WamiContext,
-            _action: &str,
-            _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Err(wami_core::error::AmiError::AccessDenied {
-                message: "denied by mock".to_string(),
-            })
-        }
     }
 
     #[tokio::test]

--- a/crates/wami/src/service/credentials/service_credential.rs
+++ b/crates/wami/src/service/credentials/service_credential.rs
@@ -185,6 +185,7 @@ impl<S: ServiceCredentialStore> ServiceCredentialService<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::auth::decision::{Decision, DenyReason};
     use crate::store::memory::InMemoryWamiStore;
     use wami_core::arn::{TenantPath, WamiArn};
 
@@ -329,8 +330,8 @@ mod tests {
             _context: &WamiContext,
             _action: &str,
             _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(false)
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Deny(DenyReason::NoMatch))
         }
         async fn check_or_deny(
             &self,

--- a/crates/wami/src/service/credentials/signing_certificate.rs
+++ b/crates/wami/src/service/credentials/signing_certificate.rs
@@ -334,16 +334,6 @@ mod tests {
         ) -> wami_core::error::Result<Decision> {
             Ok(Decision::Deny(DenyReason::NoMatch))
         }
-        async fn check_or_deny(
-            &self,
-            _context: &WamiContext,
-            _action: &str,
-            _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Err(wami_core::error::AmiError::AccessDenied {
-                message: "denied by mock".to_string(),
-            })
-        }
     }
 
     #[tokio::test]

--- a/crates/wami/src/service/credentials/signing_certificate.rs
+++ b/crates/wami/src/service/credentials/signing_certificate.rs
@@ -176,6 +176,7 @@ impl<S: SigningCertificateStore> SigningCertificateService<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::auth::decision::{Decision, DenyReason};
     use crate::store::memory::InMemoryWamiStore;
     use wami_credentials::signing_certificate::CertificateStatus;
 
@@ -330,8 +331,8 @@ mod tests {
             _context: &WamiContext,
             _action: &str,
             _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(false)
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Deny(DenyReason::NoMatch))
         }
         async fn check_or_deny(
             &self,

--- a/crates/wami/src/service/identity/group.rs
+++ b/crates/wami/src/service/identity/group.rs
@@ -192,6 +192,7 @@ impl<S: GroupStore> GroupService<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::auth::decision::{Decision, DenyReason};
     use crate::store::memory::InMemoryWamiStore;
     use crate::store::traits::UserStore;
     use crate::wami::identity::user::builder as user_builder;
@@ -359,18 +360,8 @@ mod tests {
             _ctx: &WamiContext,
             _action: &str,
             _arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(false)
-        }
-        async fn check_or_deny(
-            &self,
-            _ctx: &WamiContext,
-            _action: &str,
-            _arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Err(wami_core::error::AmiError::AccessDenied {
-                message: "denied".to_string(),
-            })
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Deny(DenyReason::NoMatch))
         }
     }
 

--- a/crates/wami/src/service/identity/role.rs
+++ b/crates/wami/src/service/identity/role.rs
@@ -152,6 +152,7 @@ impl<S: RoleStore> RoleService<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::auth::decision::{Decision, DenyReason};
     use crate::store::memory::InMemoryWamiStore;
     use wami_core::arn::{TenantPath, WamiArn};
     use wami_core::context::WamiContext;
@@ -314,8 +315,8 @@ mod tests {
             _context: &WamiContext,
             _action: &str,
             _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(false)
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Deny(DenyReason::NoMatch))
         }
         async fn check_or_deny(
             &self,

--- a/crates/wami/src/service/identity/role.rs
+++ b/crates/wami/src/service/identity/role.rs
@@ -318,16 +318,6 @@ mod tests {
         ) -> wami_core::error::Result<Decision> {
             Ok(Decision::Deny(DenyReason::NoMatch))
         }
-        async fn check_or_deny(
-            &self,
-            _context: &WamiContext,
-            _action: &str,
-            _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Err(wami_core::error::AmiError::AccessDenied {
-                message: "denied by mock".to_string(),
-            })
-        }
     }
 
     #[tokio::test]

--- a/crates/wami/src/service/identity/user.rs
+++ b/crates/wami/src/service/identity/user.rs
@@ -214,6 +214,7 @@ impl<S: UserStore> UserService<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::auth::decision::{Decision, DenyReason};
     use crate::store::memory::InMemoryWamiStore;
     use wami_core::arn::{TenantPath, WamiArn};
     use wami_core::context::WamiContext;
@@ -566,18 +567,8 @@ mod tests {
             _ctx: &WamiContext,
             _action: &str,
             _arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(false)
-        }
-        async fn check_or_deny(
-            &self,
-            _ctx: &WamiContext,
-            _action: &str,
-            _arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Err(wami_core::error::AmiError::AccessDenied {
-                message: "denied".to_string(),
-            })
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Deny(DenyReason::NoMatch))
         }
     }
 

--- a/crates/wami/src/service/policies/attachment.rs
+++ b/crates/wami/src/service/policies/attachment.rs
@@ -500,6 +500,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::auth::decision::{Decision, DenyReason};
     use crate::store::memory::InMemoryWamiStore;
     use crate::wami::identity::group::builder::build_group;
     use crate::wami::identity::role::builder::build_role;
@@ -895,18 +896,8 @@ mod tests {
             _ctx: &WamiContext,
             _action: &str,
             _arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(false)
-        }
-        async fn check_or_deny(
-            &self,
-            _ctx: &WamiContext,
-            _action: &str,
-            _arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Err(wami_core::error::AmiError::AccessDenied {
-                message: "denied".to_string(),
-            })
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Deny(DenyReason::NoMatch))
         }
     }
 

--- a/crates/wami/src/service/policies/inline.rs
+++ b/crates/wami/src/service/policies/inline.rs
@@ -1040,14 +1040,6 @@ mod tests {
         ) -> wami_core::error::Result<Decision> {
             Ok(Decision::Allow(AllowReason::RootBypass))
         }
-        async fn check_or_deny(
-            &self,
-            _context: &WamiContext,
-            _action: &str,
-            _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Ok(())
-        }
     }
 
     /// Mock authorizer that always denies.
@@ -1062,16 +1054,6 @@ mod tests {
             _resource_arn: &WamiArn,
         ) -> wami_core::error::Result<Decision> {
             Ok(Decision::Deny(DenyReason::NoMatch))
-        }
-        async fn check_or_deny(
-            &self,
-            _context: &WamiContext,
-            _action: &str,
-            _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Err(wami_core::error::AmiError::AccessDenied {
-                message: "denied by mock".to_string(),
-            })
         }
     }
 
@@ -1307,5 +1289,72 @@ mod tests {
             service.delete_role_policy(&context, request).await,
             Err(wami_core::error::AmiError::AccessDenied { .. })
         ));
+    }
+
+    #[tokio::test]
+    async fn a_malformed_policy_is_refused_on_every_write_path() {
+        // Valid JSON, invalid policy — "Actions" for "Action". All three write
+        // paths must refuse it, not just the user one.
+        let store = Arc::new(RwLock::new(InMemoryWamiStore::new()));
+        let service = InlinePolicyService::new(store.clone());
+        let context = create_test_context().await;
+        let broken = r#"{"Version":"2012-10-17","Statement":[{"Effect":"Deny","Actions":["iam:*"],"Resource":["*"]}]}"#;
+
+        {
+            let mut s = store.write().await;
+            let user = build_user("alice".to_string(), Some("/".to_string()), &context).unwrap();
+            s.create_user(user).await.unwrap();
+            let group = build_group("devs".to_string(), Some("/".to_string()), &context).unwrap();
+            s.create_group(group).await.unwrap();
+            let role = build_role(
+                "AppRole".to_string(),
+                r#"{"Version":"2012-10-17","Statement":[]}"#.to_string(),
+                Some("/".to_string()),
+                None,
+                None,
+                &context,
+            )
+            .unwrap();
+            s.create_role(role).await.unwrap();
+        }
+
+        let user_err = service
+            .put_user_policy(
+                &context,
+                PutUserPolicyRequest {
+                    user_name: "alice".to_string(),
+                    policy_name: "Broken".to_string(),
+                    policy_document: broken.to_string(),
+                },
+            )
+            .await
+            .expect_err("user path must refuse");
+        assert!(matches!(user_err, AmiError::InvalidParameter { .. }));
+
+        let group_err = service
+            .put_group_policy(
+                &context,
+                PutGroupPolicyRequest {
+                    group_name: "devs".to_string(),
+                    policy_name: "Broken".to_string(),
+                    policy_document: broken.to_string(),
+                },
+            )
+            .await
+            .expect_err("group path must refuse");
+        assert!(matches!(group_err, AmiError::InvalidParameter { .. }));
+
+        let role_err = service
+            .put_role_policy(
+                &context,
+                PutRolePolicyRequest {
+                    role_name: "AppRole".to_string(),
+                    policy_name: "Broken".to_string(),
+                    policy_document: broken.to_string(),
+                },
+            )
+            .await
+            .expect_err("role path must refuse");
+        assert!(matches!(role_err, AmiError::InvalidParameter { .. }));
     }
 }

--- a/crates/wami/src/service/policies/inline.rs
+++ b/crates/wami/src/service/policies/inline.rs
@@ -10,6 +10,7 @@ use tokio::sync::RwLock;
 use wami_core::actions::WamiAction;
 use wami_core::context::WamiContext;
 use wami_core::error::{AmiError, Result};
+use wami_core::types::PolicyDocument;
 
 pub trait InlinePolicyServiceStore: UserStore + GroupStore + RoleStore {}
 impl<T> InlinePolicyServiceStore for T where T: UserStore + GroupStore + RoleStore {}
@@ -84,10 +85,15 @@ where
                 resource: format!("User: {}", request.user_name),
             })?;
 
-        // Validate policy document is valid JSON
-        serde_json::from_str::<serde_json::Value>(&request.policy_document).map_err(|e| {
+        // Validate against PolicyDocument, not merely `Value`: a document that
+        // is valid JSON but not a valid policy — `"Actions"` for `"Action"`,
+        // say — used to be accepted here and then evaluate to nothing, so a
+        // Deny written with a typo silently stopped applying. Refusing it at
+        // the point where someone can still fix it is the other half of the
+        // fix; `parse_policy_doc` covers documents already in the store.
+        serde_json::from_str::<PolicyDocument>(&request.policy_document).map_err(|e| {
             AmiError::InvalidParameter {
-                message: format!("Invalid policy document JSON: {}", e),
+                message: format!("Invalid policy document: {}", e),
             }
         })?;
 
@@ -243,10 +249,15 @@ where
                 resource: format!("Group: {}", request.group_name),
             })?;
 
-        // Validate policy document is valid JSON
-        serde_json::from_str::<serde_json::Value>(&request.policy_document).map_err(|e| {
+        // Validate against PolicyDocument, not merely `Value`: a document that
+        // is valid JSON but not a valid policy — `"Actions"` for `"Action"`,
+        // say — used to be accepted here and then evaluate to nothing, so a
+        // Deny written with a typo silently stopped applying. Refusing it at
+        // the point where someone can still fix it is the other half of the
+        // fix; `parse_policy_doc` covers documents already in the store.
+        serde_json::from_str::<PolicyDocument>(&request.policy_document).map_err(|e| {
             AmiError::InvalidParameter {
-                message: format!("Invalid policy document JSON: {}", e),
+                message: format!("Invalid policy document: {}", e),
             }
         })?;
 
@@ -402,10 +413,15 @@ where
                 resource: format!("Role: {}", request.role_name),
             })?;
 
-        // Validate policy document is valid JSON
-        serde_json::from_str::<serde_json::Value>(&request.policy_document).map_err(|e| {
+        // Validate against PolicyDocument, not merely `Value`: a document that
+        // is valid JSON but not a valid policy — `"Actions"` for `"Action"`,
+        // say — used to be accepted here and then evaluate to nothing, so a
+        // Deny written with a typo silently stopped applying. Refusing it at
+        // the point where someone can still fix it is the other half of the
+        // fix; `parse_policy_doc` covers documents already in the store.
+        serde_json::from_str::<PolicyDocument>(&request.policy_document).map_err(|e| {
             AmiError::InvalidParameter {
-                message: format!("Invalid policy document JSON: {}", e),
+                message: format!("Invalid policy document: {}", e),
             }
         })?;
 
@@ -539,6 +555,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::auth::decision::{AllowReason, Decision, DenyReason};
     use crate::store::memory::InMemoryWamiStore;
     use crate::wami::identity::group::builder::build_group;
     use crate::wami::identity::role::builder::build_role;
@@ -1020,8 +1037,8 @@ mod tests {
             _context: &WamiContext,
             _action: &str,
             _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(true)
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Allow(AllowReason::RootBypass))
         }
         async fn check_or_deny(
             &self,
@@ -1043,8 +1060,8 @@ mod tests {
             _context: &WamiContext,
             _action: &str,
             _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(false)
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Deny(DenyReason::NoMatch))
         }
         async fn check_or_deny(
             &self,

--- a/crates/wami/src/service/policies/permissions_boundary.rs
+++ b/crates/wami/src/service/policies/permissions_boundary.rs
@@ -224,6 +224,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::auth::decision::{Decision, DenyReason};
     use crate::store::memory::InMemoryWamiStore;
     use crate::wami::identity::role::builder::build_role;
     use crate::wami::identity::user::builder::build_user;
@@ -553,8 +554,8 @@ mod tests {
             _context: &WamiContext,
             _action: &str,
             _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(false)
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Deny(DenyReason::NoMatch))
         }
         async fn check_or_deny(
             &self,

--- a/crates/wami/src/service/policies/permissions_boundary.rs
+++ b/crates/wami/src/service/policies/permissions_boundary.rs
@@ -557,16 +557,6 @@ mod tests {
         ) -> wami_core::error::Result<Decision> {
             Ok(Decision::Deny(DenyReason::NoMatch))
         }
-        async fn check_or_deny(
-            &self,
-            _context: &WamiContext,
-            _action: &str,
-            _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Err(wami_core::error::AmiError::AccessDenied {
-                message: "denied by mock".to_string(),
-            })
-        }
     }
 
     #[tokio::test]

--- a/crates/wami/src/service/policies/policy.rs
+++ b/crates/wami/src/service/policies/policy.rs
@@ -396,16 +396,6 @@ mod tests {
         ) -> wami_core::error::Result<Decision> {
             Ok(Decision::Deny(DenyReason::NoMatch))
         }
-        async fn check_or_deny(
-            &self,
-            _context: &WamiContext,
-            _action: &str,
-            _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<()> {
-            Err(wami_core::error::AmiError::AccessDenied {
-                message: "denied by mock".to_string(),
-            })
-        }
     }
 
     #[tokio::test]

--- a/crates/wami/src/service/policies/policy.rs
+++ b/crates/wami/src/service/policies/policy.rs
@@ -155,6 +155,7 @@ impl<S: PolicyStore> PolicyService<S> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::service::auth::decision::{Decision, DenyReason};
     use crate::store::memory::InMemoryWamiStore;
     use wami_core::arn::{TenantPath, WamiArn};
 
@@ -392,8 +393,8 @@ mod tests {
             _context: &WamiContext,
             _action: &str,
             _resource_arn: &WamiArn,
-        ) -> wami_core::error::Result<bool> {
-            Ok(false)
+        ) -> wami_core::error::Result<Decision> {
+            Ok(Decision::Deny(DenyReason::NoMatch))
         }
         async fn check_or_deny(
             &self,

--- a/crates/wami/src/wami/policies/evaluation/operations.rs
+++ b/crates/wami/src/wami/policies/evaluation/operations.rs
@@ -85,6 +85,7 @@ mod tests {
         PolicyDocument {
             version: "2012-10-17".to_string(),
             statement: vec![PolicyStatement {
+                sid: None,
                 effect: effect.to_string(),
                 action: actions.iter().map(|a| a.to_string()).collect(),
                 resource: vec!["*".to_string()],


### PR DESCRIPTION
Closes #100. Closes #120.

The two are one change: refusing to decide on a policy that cannot be read only makes sense once a decision can say *why*.

## #100 — a verdict cannot be audited

`authorize` returned `Result<bool>`. From `true`/`false` there is no way to write an audit line naming the statement that decided, and no way to tell a refused user what they lack.

The effect is now the variant rather than a separate field, so combinations the domain forbids — an `Allow` justified by a missing boundary — cannot be constructed at all:

```rust
Decision      = Allow(AllowReason) | Deny(DenyReason)
AllowReason   = RootBypass | Statements(NonEmpty<StatementRef>)
DenyReason    = NoMatch | Statements(NonEmpty<StatementRef>)
              | BoundaryRestricted { arn, allowed_by, denied_by }
              | BoundaryMissing { arn }
```

`BoundaryRestricted` folds two refusals whose remedies are **opposite**: an empty `denied_by` means the boundary does not cover the action (widen it), a non-empty one means it refuses it outright (remove those statements). One variant, both diagnoses.

**`PolicyStatement` gains `Sid`.** Without it the only handle on a statement is its index, which points at a different statement once the policy is rewritten — a log that is confidently wrong is worse than no log. Backward compatible in both directions: the struct does not deny unknown fields, so documents already carrying a `Sid` were being accepted and silently dropping it, and `skip_serializing_if` keeps documents without one byte-identical.

**Sources are sorted before anything is reported**, and that sort is where determinism comes from. `list_groups_for_user` and friends promise no ordering, so a SQL-backed store without an `ORDER BY` could return the same policies in a different order on two identical calls — which is exactly the SQLite consumer that motivated this work. Sorting by `PolicySource` reproduces the intended precedence (user → group → role) whatever the store did.

## #120 — a malformed Deny disappeared

`parse_policy_doc` swallowed every parse error and returned an empty document. For an `Allow` that was useless; for a `Deny` it was a **fail-open** — the statement meant to block the action stopped existing, and any `Allow` elsewhere won. One character was enough:

```
{"Effect":"Deny","Actions":["iam:*"],"Resource":["*"]}
                  ^ plural — valid JSON, not a PolicyStatement
```

It passed the write check too, which validated against `serde_json::Value` rather than `PolicyDocument`. **Both halves are fixed**: writes are refused where someone can still correct them, and evaluation refuses to decide on a document it cannot read.

That is an `Err`, not a `Deny`. A denial means *the rules forbid this*; an unreadable policy means *the rules cannot be read*. Folding the second into the first would hide a corrupt store behind what looks like an ordinary permission failure — a 403 the operator would never investigate, where it should be a 5xx that pages someone.

The boundary is read on its own path, so it is parsed and reported separately; `PolicySource::PermissionsBoundary` exists so the error can name which of the two documents failed.

## Smaller than it looks to migrate

`check_or_deny` now has a **default implementation** derived from `authorize`. An external implementor supplies one method instead of two, cannot let them drift apart, and gets a refusal message quoting the `Decision` for free. The 13 in-tree test authorizers each lost a method.

## Tests

Nine new behavioural tests, each pinning something the old API could not express:

- an allow names the statement that granted it (by `Sid`, and renders into an audit line)
- a deny reports **every** source that denied, in canonical order — not just the first
- `NoMatch` is distinguishable from an explicit deny
- root is allowed without consulting any policy
- the two boundary refusals produce their two different diagnoses
- a malformed `Deny` no longer disappears (this returned `Ok(true)` before)
- an unreadable boundary is reported *as* the boundary
- a malformed policy is refused on write

Plus four on the `Decision` types themselves, including that sources sort into evaluation order regardless of store order.

## Verification

- `cargo test --workspace --all-features` — **1480 tests, 0 failures** (772 in `wami`, doctests included)
- `cargo clippy --workspace --all-targets --all-features` — silent
- `cargo fmt --all --check` — clean
- All 27 examples run under a 30 s watchdog. The same five fail as on `main` (`06`, `07`, `19`, `21`, `25`) with identical exit codes — pre-existing, untouched.

## Design provenance

Eight iterations reviewed by four models. Two arbitrations were settled against my own first proposal — `Vec<StatementRef>` over a single source, and `Err` over a `Reason` variant — and two objections were raised against decisions three reviewers had already agreed on, one of which (the boundary was not covered by the parse check) turned out to be a real hole.

## Breaking changes

- `Authorizer::authorize` / `AuthorizationService::authorize` return `Result<Decision>` instead of `Result<bool>` — call `.is_allowed()` for the old boolean.
- `evaluate_policy_document` returns `Option<StatementHit>` instead of `PolicyEffect`.
- `parse_policy_doc` returns `Result` and takes the `PolicySource` being parsed.
- `PolicyStatement` has a new `sid` field.
- Policy documents that are valid JSON but not valid policies are rejected on write. **This will surface in consumers holding malformed documents written before the fix** — which is the point, but worth a release note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)