### PR TITLE
feat(oauth): issue, introspect and revoke machine-to-machine tokens

### DIFF
--- a/crates/wami/examples/27_oauth_client_credentials.rs
+++ b/crates/wami/examples/27_oauth_client_credentials.rs
@@ -1,0 +1,148 @@
+//! Example 27: OAuth 2.0 client credentials
+//!
+//! wami as an authorization server for machine-to-machine traffic: a service
+//! authenticates as itself and gets a short-lived signed token.
+//!
+//! What this shows, in order:
+//!
+//! 1. Registering a client — the secret is shown once and stored hashed
+//! 2. Issuing a token, and verifying it offline against the JWKS
+//! 3. Scope narrowing, and refusal of a scope the client does not hold
+//! 4. Introspection (RFC 7662) and revocation (RFC 7009)
+//! 5. Containing a compromised client in two moves
+//!
+//! Tokens are signed by the same `KeyManager` that signs STS credentials, so
+//! there is one keyset and one JWKS to publish for both.
+
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use wami::service::oauth::OAuthService;
+use wami::store::memory::InMemoryOAuthStore;
+use wami::wami::oauth::{
+    build_client, generate_client_secret, GrantRequest, GrantType, OAuthClaims,
+};
+use wami::wami::sts::jwt::KeyManager;
+
+const AUDIENCE: &str = "reporting-api";
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    println!("🔑 OAuth 2.0 — client credentials\n");
+    println!("{}", "=".repeat(60));
+
+    // ── 1. Register a client ─────────────────────────────────────
+    println!("\n📝 Step 1: Register a client");
+
+    let store = Arc::new(RwLock::new(InMemoryOAuthStore::new()));
+    let keys = Arc::new(KeyManager::generate());
+    let service = OAuthService::new(store, keys.clone(), "wami-oauth".to_string());
+
+    let secret = generate_client_secret();
+    let client = build_client(
+        "nightly-reports".to_string(),
+        &secret,
+        "Nightly reporting job".to_string(),
+        vec![GrantType::ClientCredentials],
+        vec!["reports:read".to_string(), "reports:write".to_string()],
+        AUDIENCE.to_string(),
+    )?;
+    let registered = service.register_client(client).await?;
+
+    println!("✅ client_id: {}", registered.client_id);
+    println!(
+        "   secret:    {}… (shown once, stored hashed)",
+        &secret[..16]
+    );
+    println!("   scopes:    {}", registered.scopes.join(", "));
+
+    // ── 2. Issue a token ─────────────────────────────────────────
+    println!("\n🎟️  Step 2: Issue a token");
+
+    let token = service
+        .issue_token(GrantRequest::ClientCredentials {
+            client_id: "nightly-reports".to_string(),
+            client_secret: secret.clone(),
+            scope: vec!["reports:read".to_string()],
+        })
+        .await?;
+
+    println!(
+        "✅ {} token, expires in {}s",
+        token.token_type, token.expires_in
+    );
+    println!("   granted scope: {}", token.scope);
+
+    // Any holder of the public key can check it without asking wami.
+    let claims: OAuthClaims = keys.verify_claims(&token.access_token, AUDIENCE)?;
+    println!("\n🔍 Verified offline against the JWKS:");
+    println!(
+        "   sub={} iss={} jti={}",
+        claims.sub,
+        claims.iss,
+        &claims.jti[..8]
+    );
+    println!(
+        "   the JWKS has {} key(s) to publish",
+        service.jwks().keys.len()
+    );
+
+    // ── 3. Scopes are a ceiling, not a suggestion ────────────────
+    println!("\n🚧 Step 3: Scope enforcement");
+
+    let refused = service
+        .issue_token(GrantRequest::ClientCredentials {
+            client_id: "nightly-reports".to_string(),
+            client_secret: secret.clone(),
+            scope: vec!["billing:write".to_string()],
+        })
+        .await;
+    match refused {
+        Err(e) => println!("✅ refused a scope it does not hold: {e}"),
+        Ok(_) => println!("❌ a scope outside the client's set was granted!"),
+    }
+
+    // ── 4. Introspection and revocation ──────────────────────────
+    println!("\n🔎 Step 4: Introspection, then revocation");
+
+    let info = service
+        .introspect_token(&token.access_token, AUDIENCE)
+        .await?;
+    println!("✅ active={} client_id={:?}", info.active, info.client_id);
+
+    service.revoke_token(&token.access_token, AUDIENCE).await?;
+    let after = service
+        .introspect_token(&token.access_token, AUDIENCE)
+        .await?;
+    println!("✅ after revocation: active={}", after.active);
+    println!("   (nothing else is disclosed — RFC 7662 forbids it)");
+
+    // ── 5. Containing a compromise ───────────────────────────────
+    println!("\n🚨 Step 5: The client's secret leaked");
+
+    for _ in 0..3 {
+        service
+            .issue_token(GrantRequest::ClientCredentials {
+                client_id: "nightly-reports".to_string(),
+                client_secret: secret.clone(),
+                scope: vec!["reports:read".to_string()],
+            })
+            .await?;
+    }
+
+    service.disable_client("nightly-reports").await?;
+    println!("✅ client disabled — no new tokens");
+
+    let revoked = service.revoke_all_for_client("nightly-reports").await?;
+    println!("✅ revoked {revoked} token(s) already in the wild");
+
+    println!("\n{}", "=".repeat(60));
+    println!("⚠️  The limit worth knowing");
+    println!("{}", "=".repeat(60));
+    println!("Revocation binds on whoever introspects. A verifier checking the");
+    println!("signature offline keeps accepting a revoked token until it expires —");
+    println!("which is why the default lifetime is 15 minutes, and why anything");
+    println!("with immediate cost should introspect rather than verify locally.");
+
+    println!("\n✅ Example completed successfully!");
+    Ok(())
+}

--- a/crates/wami/src/lib.rs
+++ b/crates/wami/src/lib.rs
@@ -118,9 +118,10 @@ pub use service::{
     AssumeRoleService, AttachmentService, AuthenticationService, AuthorizationService,
     CredentialReportService, EvaluationService, FederationService, GroupService, IdentityService,
     InlinePolicyService, InstanceService as SsoInstanceService, LoginProfileService,
-    MfaDeviceService, PermissionSetService, PolicyService, RoleService, ServerCertificateService,
-    ServiceCredentialService, ServiceLinkedRoleService, SessionService, SessionTokenService,
-    SigningCertificateService, TenantService, TrustedTokenIssuerService, UserService,
+    MfaDeviceService, OAuthService, PermissionSetService, PolicyService, RoleService,
+    ServerCertificateService, ServiceCredentialService, ServiceLinkedRoleService, SessionService,
+    SessionTokenService, SigningCertificateService, TenantService, TrustedTokenIssuerService,
+    UserService,
 };
 
 // Re-export WAMI modules for convenience (Legacy compatibility)

--- a/crates/wami/src/service/mod.rs
+++ b/crates/wami/src/service/mod.rs
@@ -33,6 +33,7 @@ pub mod auth;
 pub mod credentials;
 pub mod gdpr;
 pub mod identity;
+pub mod oauth;
 pub mod policies;
 pub mod reports;
 pub mod sso_admin;
@@ -49,6 +50,7 @@ pub use gdpr::GdprService;
 pub use identity::{
     GroupService, IdentityProviderService, RoleService, ServiceLinkedRoleService, UserService,
 };
+pub use oauth::{OAuthService, OAuthStore};
 pub use policies::{
     AttachmentService, EvaluationService, InlinePolicyService, PermissionsBoundaryService,
     PolicyService,

--- a/crates/wami/src/service/oauth/mod.rs
+++ b/crates/wami/src/service/oauth/mod.rs
@@ -1,0 +1,501 @@
+//! OAuth 2.0 authorization server — machine-to-machine grants.
+//!
+//! Issues short-lived signed JWTs to services that authenticate as themselves,
+//! and answers introspection and revocation for them.
+//!
+//! # Why a store is involved at all
+//!
+//! A signed token is verifiable offline: any holder of the public key can check
+//! it without asking wami anything. That is the point, and it is also why
+//! revocation needs a record — a signed token stays valid until its `exp` no
+//! matter what the issuer later decides. Everything else here could be
+//! stateless; revocation cannot.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use std::sync::Arc;
+//! use tokio::sync::RwLock;
+//! use wami::store::memory::InMemoryOAuthStore;
+//! use wami::wami::oauth::{build_client, GrantRequest, GrantType};
+//! use wami::wami::sts::jwt::KeyManager;
+//! use wami::service::oauth::OAuthService;
+//!
+//! # async fn run() -> Result<(), Box<dyn std::error::Error>> {
+//! let store = Arc::new(RwLock::new(InMemoryOAuthStore::new()));
+//! let keys = Arc::new(KeyManager::generate());
+//! let service = OAuthService::new(store, keys, "wami".to_string());
+//!
+//! let client = build_client(
+//!     "reporting".into(),
+//!     "s3cret",
+//!     "Reporting job".into(),
+//!     vec![GrantType::ClientCredentials],
+//!     vec!["reports:read".into()],
+//!     "wami".into(),
+//! )?;
+//! service.register_client(client).await?;
+//!
+//! let token = service
+//!     .issue_token(GrantRequest::ClientCredentials {
+//!         client_id: "reporting".into(),
+//!         client_secret: "s3cret".into(),
+//!         scope: vec!["reports:read".into()],
+//!     })
+//!     .await?;
+//! println!("{} expires in {}s", token.token_type, token.expires_in);
+//! # Ok(())
+//! # }
+//! ```
+
+use chrono::{Duration, Utc};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use wami_core::error::{AmiError, Result};
+
+use crate::service::auth::verify_secret;
+use crate::store::traits::oauth::{OAuthClientStore, OAuthTokenStore};
+use crate::wami::oauth::{
+    builder, GrantRequest, GrantType, OAuthClaims, OAuthClient, TokenIntrospection, TokenResponse,
+    DEFAULT_TOKEN_LIFETIME,
+};
+use crate::wami::sts::jwt::KeyManager;
+
+/// Combined bound for a store that can hold clients and tokens.
+pub trait OAuthStore: OAuthClientStore + OAuthTokenStore {}
+impl<T: OAuthClientStore + OAuthTokenStore> OAuthStore for T {}
+
+/// Issues, introspects and revokes OAuth access tokens.
+pub struct OAuthService<S> {
+    store: Arc<RwLock<S>>,
+    keys: Arc<KeyManager>,
+    issuer: String,
+    lifetime: Duration,
+}
+
+impl<S: OAuthStore> OAuthService<S> {
+    /// Build a service signing with `keys` and claiming `issuer`.
+    pub fn new(store: Arc<RwLock<S>>, keys: Arc<KeyManager>, issuer: String) -> Self {
+        Self {
+            store,
+            keys,
+            issuer,
+            lifetime: DEFAULT_TOKEN_LIFETIME,
+        }
+    }
+
+    /// Override how long issued tokens live.
+    ///
+    /// Shorter narrows the window in which a revoked token is still accepted by
+    /// an offline verifier; longer reduces how often clients come back.
+    pub fn with_token_lifetime(mut self, lifetime: Duration) -> Self {
+        self.lifetime = lifetime;
+        self
+    }
+
+    /// The public keys a verifier needs, as a JWKS.
+    ///
+    /// Serving this over HTTP is transport, and belongs to whatever hosts the
+    /// library.
+    pub fn jwks(&self) -> crate::wami::sts::jwt::Jwks {
+        self.keys.jwks()
+    }
+
+    /// Register a client.
+    pub async fn register_client(&self, client: OAuthClient) -> Result<OAuthClient> {
+        self.store.write().await.create_oauth_client(client).await
+    }
+
+    /// Authenticate a client by id and secret.
+    ///
+    /// Every failure — unknown id, wrong secret, disabled client — is reported
+    /// the same way. Distinguishing them would turn this into an oracle for
+    /// which client ids exist.
+    pub async fn validate_client(&self, client_id: &str, secret: &str) -> Result<OAuthClient> {
+        let refused = || AmiError::AccessDenied {
+            message: "invalid client credentials".to_string(),
+        };
+
+        let client = self
+            .store
+            .read()
+            .await
+            .get_oauth_client(client_id)
+            .await?
+            .ok_or_else(refused)?;
+
+        if !client.enabled || !verify_secret(secret, &client.secret_hash)? {
+            return Err(refused());
+        }
+
+        Ok(client)
+    }
+
+    /// Issue an access token.
+    ///
+    /// # Errors
+    ///
+    /// [`AmiError::AccessDenied`] if the credentials are wrong, the client is
+    /// disabled, or it is not registered for this grant.
+    /// [`AmiError::InvalidParameter`] if it asked for a scope it does not hold.
+    pub async fn issue_token(&self, request: GrantRequest) -> Result<TokenResponse> {
+        let GrantRequest::ClientCredentials {
+            client_id,
+            client_secret,
+            scope,
+        } = request;
+
+        let client = self.validate_client(&client_id, &client_secret).await?;
+
+        if !client.allows_grant(GrantType::ClientCredentials) {
+            return Err(AmiError::AccessDenied {
+                message: format!("client {client_id} may not use the client_credentials grant"),
+            });
+        }
+
+        let granted =
+            client
+                .narrow_scopes(&scope)
+                .map_err(|refused| AmiError::InvalidParameter {
+                    message: format!("client {client_id} is not entitled to scope {refused}"),
+                })?;
+
+        let issued_at = Utc::now();
+        let claims =
+            builder::build_claims(&client, &granted, &self.issuer, issued_at, self.lifetime);
+        let signed = self
+            .keys
+            .sign_claims(&claims)
+            .map_err(|e| AmiError::StoreError(format!("failed to sign token: {e}")))?;
+
+        // Recorded before it is handed out: a token the caller holds but the
+        // store never saw could not be revoked.
+        self.store
+            .write()
+            .await
+            .record_oauth_token(builder::build_token_record(&claims, issued_at))
+            .await?;
+
+        Ok(builder::build_response(signed, &granted, self.lifetime))
+    }
+
+    /// Answer an introspection request — RFC 7662.
+    ///
+    /// Never fails on a bad token: an expired, revoked, forged or unknown token
+    /// all return `active: false` with nothing else. Returning an error instead
+    /// would let a caller tell those apart.
+    pub async fn introspect_token(
+        &self,
+        token: &str,
+        audience: &str,
+    ) -> Result<TokenIntrospection> {
+        let Ok(claims) = self.keys.verify_claims::<OAuthClaims>(token, audience) else {
+            return Ok(TokenIntrospection::inactive());
+        };
+
+        // The signature holds, but the issuer may have revoked it since.
+        let Some(record) = self.store.read().await.get_oauth_token(&claims.jti).await? else {
+            return Ok(TokenIntrospection::inactive());
+        };
+        if !record.is_active_at(Utc::now()) {
+            return Ok(TokenIntrospection::inactive());
+        }
+
+        Ok(TokenIntrospection {
+            active: true,
+            scope: (!claims.scope.is_empty()).then(|| claims.scope.clone()),
+            client_id: Some(claims.client_id),
+            sub: Some(claims.sub),
+            exp: Some(claims.exp),
+            iat: Some(claims.iat),
+            jti: Some(claims.jti),
+        })
+    }
+
+    /// Revoke a token — RFC 7009.
+    ///
+    /// Succeeds whether or not the token existed, as the RFC requires: the
+    /// caller learns only that the token is not usable, never whether it ever
+    /// was. The `jti` is read from the signature, so a forged token revokes
+    /// nothing.
+    ///
+    /// Note the limit this cannot escape: a verifier checking the signature
+    /// offline will keep accepting the token until it expires. Revocation binds
+    /// on anyone who introspects, which is why token lifetimes are short.
+    pub async fn revoke_token(&self, token: &str, audience: &str) -> Result<()> {
+        if let Ok(claims) = self.keys.verify_claims::<OAuthClaims>(token, audience) {
+            self.store
+                .write()
+                .await
+                .revoke_oauth_token(&claims.jti)
+                .await?;
+        }
+        Ok(())
+    }
+
+    /// Revoke every token a client holds, and return how many.
+    ///
+    /// What to reach for when a client is compromised. Disabling the client
+    /// stops new tokens; this stops the ones already issued.
+    pub async fn revoke_all_for_client(&self, client_id: &str) -> Result<u64> {
+        self.store
+            .write()
+            .await
+            .revoke_oauth_tokens_for_client(client_id)
+            .await
+    }
+
+    /// Stop a client obtaining new tokens, leaving existing ones alone.
+    pub async fn disable_client(&self, client_id: &str) -> Result<OAuthClient> {
+        let mut store = self.store.write().await;
+        let mut client =
+            store
+                .get_oauth_client(client_id)
+                .await?
+                .ok_or_else(|| AmiError::ResourceNotFound {
+                    resource: format!("OAuth client {client_id}"),
+                })?;
+        client.enabled = false;
+        store.update_oauth_client(client).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::memory::InMemoryOAuthStore;
+    use crate::wami::oauth::build_client;
+
+    const AUD: &str = "wami";
+
+    fn service() -> OAuthService<InMemoryOAuthStore> {
+        OAuthService::new(
+            Arc::new(RwLock::new(InMemoryOAuthStore::new())),
+            Arc::new(KeyManager::generate()),
+            "wami-oauth".to_string(),
+        )
+    }
+
+    async fn with_client(scopes: &[&str]) -> OAuthService<InMemoryOAuthStore> {
+        let service = service();
+        let client = build_client(
+            "svc".into(),
+            "s3cret",
+            "Service".into(),
+            vec![GrantType::ClientCredentials],
+            scopes.iter().map(|s| s.to_string()).collect(),
+            AUD.to_string(),
+        )
+        .unwrap();
+        service.register_client(client).await.unwrap();
+        service
+    }
+
+    fn grant(scope: &[&str]) -> GrantRequest {
+        GrantRequest::ClientCredentials {
+            client_id: "svc".into(),
+            client_secret: "s3cret".into(),
+            scope: scope.iter().map(|s| s.to_string()).collect(),
+        }
+    }
+
+    #[tokio::test]
+    async fn a_token_is_signed_by_the_shared_keyset_and_verifies_offline() {
+        let service = with_client(&["read"]).await;
+        let response = service.issue_token(grant(&["read"])).await.unwrap();
+
+        assert_eq!(response.token_type, "Bearer");
+        assert_eq!(response.expires_in, 900);
+        assert_eq!(response.scope, "read");
+
+        // The point of signing with the STS keyset: the same JWKS verifies it,
+        // with no call back to wami.
+        let claims = service
+            .jwks()
+            .keys
+            .first()
+            .map(|_| {
+                service
+                    .keys
+                    .verify_claims::<OAuthClaims>(&response.access_token, AUD)
+                    .unwrap()
+            })
+            .unwrap();
+        assert_eq!(claims.client_id, "svc");
+        assert_eq!(claims.iss, "wami-oauth");
+    }
+
+    #[tokio::test]
+    async fn every_authentication_failure_looks_the_same() {
+        // Otherwise the endpoint becomes an oracle for which client ids exist.
+        let service = with_client(&["read"]).await;
+        service.disable_client("svc").await.unwrap();
+
+        let disabled = service.validate_client("svc", "s3cret").await.unwrap_err();
+        let unknown = service
+            .validate_client("ghost", "s3cret")
+            .await
+            .unwrap_err();
+        let wrong = service.validate_client("svc", "nope").await.unwrap_err();
+
+        for err in [&disabled, &unknown, &wrong] {
+            assert!(matches!(err, AmiError::AccessDenied { .. }), "{err:?}");
+        }
+        assert_eq!(disabled.to_string(), unknown.to_string());
+        assert_eq!(unknown.to_string(), wrong.to_string());
+    }
+
+    #[tokio::test]
+    async fn a_scope_the_client_does_not_hold_is_refused() {
+        let service = with_client(&["read"]).await;
+        let err = service
+            .issue_token(grant(&["read", "write"]))
+            .await
+            .unwrap_err();
+
+        assert!(matches!(err, AmiError::InvalidParameter { .. }));
+        assert!(err.to_string().contains("write"));
+    }
+
+    #[tokio::test]
+    async fn an_empty_scope_request_yields_everything_the_client_holds() {
+        let service = with_client(&["read", "write"]).await;
+        let response = service.issue_token(grant(&[])).await.unwrap();
+        assert_eq!(response.scope, "read write");
+    }
+
+    #[tokio::test]
+    async fn introspection_reports_an_issued_token_as_active() {
+        let service = with_client(&["read"]).await;
+        let response = service.issue_token(grant(&["read"])).await.unwrap();
+
+        let info = service
+            .introspect_token(&response.access_token, AUD)
+            .await
+            .unwrap();
+        assert!(info.active);
+        assert_eq!(info.client_id.as_deref(), Some("svc"));
+        assert_eq!(info.scope.as_deref(), Some("read"));
+    }
+
+    #[tokio::test]
+    async fn a_revoked_token_introspects_as_inactive_and_reveals_nothing() {
+        let service = with_client(&["read"]).await;
+        let response = service.issue_token(grant(&["read"])).await.unwrap();
+
+        service
+            .revoke_token(&response.access_token, AUD)
+            .await
+            .unwrap();
+
+        let info = service
+            .introspect_token(&response.access_token, AUD)
+            .await
+            .unwrap();
+        assert_eq!(info, TokenIntrospection::inactive());
+    }
+
+    #[tokio::test]
+    async fn a_forged_or_unknown_token_is_inactive_rather_than_an_error() {
+        let service = with_client(&["read"]).await;
+
+        // Signed by somebody else entirely.
+        let stranger = OAuthService::new(
+            Arc::new(RwLock::new(InMemoryOAuthStore::new())),
+            Arc::new(KeyManager::generate()),
+            "elsewhere".to_string(),
+        );
+        let other_client = build_client(
+            "svc".into(),
+            "s3cret",
+            "Service".into(),
+            vec![GrantType::ClientCredentials],
+            vec!["read".into()],
+            AUD.to_string(),
+        )
+        .unwrap();
+        stranger.register_client(other_client).await.unwrap();
+        let foreign = stranger.issue_token(grant(&["read"])).await.unwrap();
+
+        for token in [foreign.access_token.as_str(), "not-a-jwt", ""] {
+            assert!(!service.introspect_token(token, AUD).await.unwrap().active);
+        }
+    }
+
+    #[tokio::test]
+    async fn revoking_an_unknown_token_still_succeeds() {
+        // RFC 7009: the caller must not learn whether the token ever existed.
+        let service = with_client(&["read"]).await;
+        service.revoke_token("not-a-jwt", AUD).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn a_token_for_another_audience_does_not_introspect_here() {
+        // The audience split #114 made possible: a token minted for one
+        // consumer must not read as active at another.
+        let service = with_client(&["read"]).await;
+        let response = service.issue_token(grant(&["read"])).await.unwrap();
+
+        assert!(
+            !service
+                .introspect_token(&response.access_token, "somewhere-else")
+                .await
+                .unwrap()
+                .active
+        );
+    }
+
+    #[tokio::test]
+    async fn compromising_a_client_can_be_contained_in_two_moves() {
+        let service = with_client(&["read"]).await;
+        let first = service.issue_token(grant(&["read"])).await.unwrap();
+        let second = service.issue_token(grant(&["read"])).await.unwrap();
+
+        // Stop the bleeding: no new tokens...
+        service.disable_client("svc").await.unwrap();
+        assert!(service.issue_token(grant(&["read"])).await.is_err());
+
+        // ...and kill the ones already out.
+        assert_eq!(service.revoke_all_for_client("svc").await.unwrap(), 2);
+        for token in [&first, &second] {
+            assert!(
+                !service
+                    .introspect_token(&token.access_token, AUD)
+                    .await
+                    .unwrap()
+                    .active
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn a_shorter_lifetime_narrows_the_revocation_window() {
+        let service = with_client(&["read"])
+            .await
+            .with_token_lifetime(Duration::seconds(30));
+        let response = service.issue_token(grant(&["read"])).await.unwrap();
+        assert_eq!(response.expires_in, 30);
+    }
+
+    #[tokio::test]
+    async fn a_client_registered_without_this_grant_cannot_use_it() {
+        let service = service();
+        let mut client = build_client(
+            "svc".into(),
+            "s3cret",
+            "Service".into(),
+            vec![GrantType::ClientCredentials],
+            vec!["read".into()],
+            AUD.to_string(),
+        )
+        .unwrap();
+        // Registered for no grant at all — as a store row written elsewhere
+        // could be, since the builder refuses to create one.
+        client.grant_types.clear();
+        service.register_client(client).await.unwrap();
+
+        let err = service.issue_token(grant(&["read"])).await.unwrap_err();
+        assert!(matches!(err, AmiError::AccessDenied { .. }));
+        assert!(err.to_string().contains("client_credentials"));
+    }
+}

--- a/crates/wami/src/store/memory/mod.rs
+++ b/crates/wami/src/store/memory/mod.rs
@@ -12,6 +12,7 @@
 //! - `InMemoryTenantStore` - Tenant management
 //! - `InMemoryStore` - Combines all stores into a single unified interface
 
+mod oauth;
 mod sso_admin;
 mod sts;
 mod tenant;
@@ -25,6 +26,7 @@ mod policies;
 mod reports;
 
 // Store implementations
+pub use oauth::InMemoryOAuthStore;
 pub use sso_admin::InMemorySsoAdminStore;
 pub use sts::InMemoryStsStore;
 pub use tenant::InMemoryTenantStore;

--- a/crates/wami/src/store/memory/oauth/mod.rs
+++ b/crates/wami/src/store/memory/oauth/mod.rs
@@ -1,0 +1,224 @@
+//! In-memory OAuth store.
+//!
+//! Throwaway, like the rest of `store/memory` — it exists so the service layer
+//! and its tests have something to run against, not to be deployed.
+
+use async_trait::async_trait;
+use chrono::Utc;
+use std::collections::HashMap;
+use wami_core::error::{AmiError, Result};
+
+use crate::store::traits::oauth::{OAuthClientStore, OAuthTokenStore};
+use crate::wami::oauth::{AccessToken, OAuthClient};
+
+/// Clients and issued tokens, held in maps.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryOAuthStore {
+    clients: HashMap<String, OAuthClient>,
+    tokens: HashMap<String, AccessToken>,
+}
+
+impl InMemoryOAuthStore {
+    /// An empty store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+#[async_trait]
+impl OAuthClientStore for InMemoryOAuthStore {
+    async fn create_oauth_client(&mut self, client: OAuthClient) -> Result<OAuthClient> {
+        if self.clients.contains_key(&client.client_id) {
+            return Err(AmiError::ResourceExists {
+                resource: format!("OAuth client {}", client.client_id),
+            });
+        }
+        self.clients
+            .insert(client.client_id.clone(), client.clone());
+        Ok(client)
+    }
+
+    async fn get_oauth_client(&self, client_id: &str) -> Result<Option<OAuthClient>> {
+        Ok(self.clients.get(client_id).cloned())
+    }
+
+    async fn update_oauth_client(&mut self, client: OAuthClient) -> Result<OAuthClient> {
+        if !self.clients.contains_key(&client.client_id) {
+            return Err(AmiError::ResourceNotFound {
+                resource: format!("OAuth client {}", client.client_id),
+            });
+        }
+        self.clients
+            .insert(client.client_id.clone(), client.clone());
+        Ok(client)
+    }
+
+    async fn delete_oauth_client(&mut self, client_id: &str) -> Result<()> {
+        self.clients.remove(client_id);
+        Ok(())
+    }
+
+    async fn list_oauth_clients(&self) -> Result<Vec<OAuthClient>> {
+        let mut clients: Vec<_> = self.clients.values().cloned().collect();
+        // Sorted so a listing does not depend on hash order — the same reason
+        // authorization sorts its sources.
+        clients.sort_by(|a, b| a.client_id.cmp(&b.client_id));
+        Ok(clients)
+    }
+}
+
+#[async_trait]
+impl OAuthTokenStore for InMemoryOAuthStore {
+    async fn record_oauth_token(&mut self, token: AccessToken) -> Result<AccessToken> {
+        self.tokens.insert(token.jti.clone(), token.clone());
+        Ok(token)
+    }
+
+    async fn get_oauth_token(&self, jti: &str) -> Result<Option<AccessToken>> {
+        Ok(self.tokens.get(jti).cloned())
+    }
+
+    async fn revoke_oauth_token(&mut self, jti: &str) -> Result<bool> {
+        match self.tokens.get_mut(jti) {
+            Some(token) if token.revoked_at.is_none() => {
+                token.revoked_at = Some(Utc::now());
+                Ok(true)
+            }
+            _ => Ok(false),
+        }
+    }
+
+    async fn revoke_oauth_tokens_for_client(&mut self, client_id: &str) -> Result<u64> {
+        let now = Utc::now();
+        let mut revoked = 0;
+        for token in self.tokens.values_mut() {
+            if token.client_id == client_id && token.revoked_at.is_none() {
+                token.revoked_at = Some(now);
+                revoked += 1;
+            }
+        }
+        Ok(revoked)
+    }
+
+    async fn list_oauth_tokens_for_client(&self, client_id: &str) -> Result<Vec<AccessToken>> {
+        let mut tokens: Vec<_> = self
+            .tokens
+            .values()
+            .filter(|t| t.client_id == client_id)
+            .cloned()
+            .collect();
+        tokens.sort_by_key(|t| t.issued_at);
+        Ok(tokens)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::wami::oauth::{build_client, GrantType};
+
+    fn a_client(id: &str) -> OAuthClient {
+        build_client(
+            id.to_string(),
+            "secret",
+            "Test".to_string(),
+            vec![GrantType::ClientCredentials],
+            vec!["read".to_string()],
+            "wami".to_string(),
+        )
+        .unwrap()
+    }
+
+    fn a_token(jti: &str, client_id: &str) -> AccessToken {
+        AccessToken {
+            jti: jti.to_string(),
+            client_id: client_id.to_string(),
+            scopes: vec!["read".to_string()],
+            issued_at: Utc::now(),
+            expires_at: Utc::now() + chrono::Duration::minutes(15),
+            revoked_at: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn a_client_id_cannot_be_registered_twice() {
+        let mut store = InMemoryOAuthStore::new();
+        store.create_oauth_client(a_client("svc")).await.unwrap();
+
+        let err = store
+            .create_oauth_client(a_client("svc"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AmiError::ResourceExists { .. }));
+    }
+
+    #[tokio::test]
+    async fn updating_an_unknown_client_is_an_error_not_an_insert() {
+        let mut store = InMemoryOAuthStore::new();
+        let err = store
+            .update_oauth_client(a_client("ghost"))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, AmiError::ResourceNotFound { .. }));
+        assert!(store.get_oauth_client("ghost").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn revoking_twice_reports_only_the_first_as_a_change() {
+        let mut store = InMemoryOAuthStore::new();
+        store
+            .record_oauth_token(a_token("j1", "svc"))
+            .await
+            .unwrap();
+
+        assert!(store.revoke_oauth_token("j1").await.unwrap());
+        assert!(!store.revoke_oauth_token("j1").await.unwrap());
+        assert!(!store.revoke_oauth_token("never-existed").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn revoking_a_client_stops_every_token_it_holds_and_no_others() {
+        let mut store = InMemoryOAuthStore::new();
+        store
+            .record_oauth_token(a_token("j1", "svc"))
+            .await
+            .unwrap();
+        store
+            .record_oauth_token(a_token("j2", "svc"))
+            .await
+            .unwrap();
+        store
+            .record_oauth_token(a_token("j3", "other"))
+            .await
+            .unwrap();
+
+        assert_eq!(
+            store.revoke_oauth_tokens_for_client("svc").await.unwrap(),
+            2
+        );
+        // Already-revoked tokens are not counted a second time.
+        assert_eq!(
+            store.revoke_oauth_tokens_for_client("svc").await.unwrap(),
+            0
+        );
+
+        let untouched = store.get_oauth_token("j3").await.unwrap().unwrap();
+        assert!(untouched.revoked_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn listings_do_not_depend_on_hash_order() {
+        let mut store = InMemoryOAuthStore::new();
+        for id in ["c", "a", "b"] {
+            store.create_oauth_client(a_client(id)).await.unwrap();
+        }
+        let ids: Vec<_> = store
+            .list_oauth_clients()
+            .await
+            .unwrap()
+            .into_iter()
+            .map(|c| c.client_id)
+            .collect();
+        assert_eq!(ids, vec!["a", "b", "c"]);
+    }
+}

--- a/crates/wami/src/store/traits/mod.rs
+++ b/crates/wami/src/store/traits/mod.rs
@@ -34,6 +34,7 @@ mod wami; // WAMI store (identity + credentials + policies) // SSO Admin store (
 
 // Supporting trait modules
 pub mod gdpr;
+pub mod oauth;
 mod tenant;
 
 // Export sub-traits from identity
@@ -55,6 +56,7 @@ pub use reports::CredentialReportStore;
 
 // Export composite traits
 pub use gdpr::{AuditStore, ConsentStore};
+pub use oauth::{OAuthClientStore, OAuthTokenStore};
 pub use sso_admin::{
     AccountAssignmentStore, ApplicationStore, PermissionSetStore, SsoAdminStore, SsoInstanceStore,
     TrustedTokenIssuerStore,

--- a/crates/wami/src/store/traits/oauth/mod.rs
+++ b/crates/wami/src/store/traits/oauth/mod.rs
@@ -1,0 +1,61 @@
+//! OAuth store traits.
+//!
+//! Both names carry the `OAuth` prefix on purpose. `ConsentStore` is already
+//! taken by GDPR and `SessionStore` by STS, and the user-facing OAuth flows
+//! will want both names for entirely different concepts. Prefixing now costs
+//! nothing and avoids a rename later, when consumers have already implemented
+//! against them.
+
+use async_trait::async_trait;
+use wami_core::error::Result;
+
+use crate::wami::oauth::{AccessToken, OAuthClient};
+
+/// Storage for registered OAuth clients.
+#[async_trait]
+pub trait OAuthClientStore: Send + Sync {
+    /// Register a client. Fails if `client_id` is taken.
+    async fn create_oauth_client(&mut self, client: OAuthClient) -> Result<OAuthClient>;
+
+    /// Look a client up by its public identifier.
+    async fn get_oauth_client(&self, client_id: &str) -> Result<Option<OAuthClient>>;
+
+    /// Replace a client's record — used to disable it, or rotate its secret.
+    async fn update_oauth_client(&mut self, client: OAuthClient) -> Result<OAuthClient>;
+
+    /// Remove a client. Tokens it already holds stay valid until they expire
+    /// unless they are revoked too; deleting the client is not a revocation.
+    async fn delete_oauth_client(&mut self, client_id: &str) -> Result<()>;
+
+    /// Every registered client.
+    async fn list_oauth_clients(&self) -> Result<Vec<OAuthClient>>;
+}
+
+/// Storage for issued tokens, so they can be revoked before they expire.
+///
+/// A signed JWT is valid until its `exp` no matter what the issuer thinks.
+/// Revocation is the one operation that cannot be done offline, and this trait
+/// is what makes it possible: everything else about a token can be checked from
+/// its signature alone.
+#[async_trait]
+pub trait OAuthTokenStore: Send + Sync {
+    /// Record a token at issuance.
+    async fn record_oauth_token(&mut self, token: AccessToken) -> Result<AccessToken>;
+
+    /// Look a token up by its `jti`.
+    async fn get_oauth_token(&self, jti: &str) -> Result<Option<AccessToken>>;
+
+    /// Mark a token revoked. Returns whether it existed and was not already
+    /// revoked, so a caller can distinguish "done" from "nothing to do" —
+    /// though RFC 7009 requires both to look the same on the wire.
+    async fn revoke_oauth_token(&mut self, jti: &str) -> Result<bool>;
+
+    /// Revoke every token a client holds, returning how many were affected.
+    ///
+    /// The operation an operator reaches for when a client is compromised:
+    /// disabling the client stops new tokens, this stops the ones already out.
+    async fn revoke_oauth_tokens_for_client(&mut self, client_id: &str) -> Result<u64>;
+
+    /// Tokens issued to a client, revoked ones included.
+    async fn list_oauth_tokens_for_client(&self, client_id: &str) -> Result<Vec<AccessToken>>;
+}

--- a/crates/wami/src/wami/mod.rs
+++ b/crates/wami/src/wami/mod.rs
@@ -81,6 +81,9 @@ pub mod tenant;
 /// GDPR compliance, consent management, audit trail, and data rights
 pub mod gdpr;
 
+/// OAuth 2.0 authorization server (machine-to-machine grants).
+pub mod oauth;
+
 // Client operations (IAM operations)
 // Operations moved to service/ layer
 // pub mod operations;

--- a/crates/wami/src/wami/oauth/builder.rs
+++ b/crates/wami/src/wami/oauth/builder.rs
@@ -1,0 +1,236 @@
+//! Pure constructors for OAuth domain objects.
+//!
+//! No store, no clock injection beyond what is passed in — the service layer
+//! owns persistence, these build the values it persists.
+
+use chrono::{DateTime, Duration, Utc};
+use uuid::Uuid;
+use wami_core::error::{AmiError, Result};
+
+use super::model::{AccessToken, GrantType, OAuthClaims, OAuthClient, TokenResponse};
+
+/// How long an issued token lives.
+///
+/// Short by intent. A signed token cannot be recalled once handed out, so the
+/// window between revoking a client and its last token dying is exactly this
+/// value — see [`crate::service::oauth::OAuthService::revoke_token`].
+pub const DEFAULT_TOKEN_LIFETIME: Duration = Duration::minutes(15);
+
+/// Register a client, hashing the supplied secret.
+///
+/// The caller keeps the plaintext secret: this is the only moment it exists
+/// outside the client's own configuration, exactly as with access keys.
+pub fn build_client(
+    client_id: String,
+    plaintext_secret: &str,
+    name: String,
+    grant_types: Vec<GrantType>,
+    scopes: Vec<String>,
+    audience: String,
+) -> Result<OAuthClient> {
+    if client_id.trim().is_empty() {
+        return Err(AmiError::InvalidParameter {
+            message: "client_id cannot be empty".to_string(),
+        });
+    }
+    if plaintext_secret.is_empty() {
+        return Err(AmiError::InvalidParameter {
+            message: "client secret cannot be empty".to_string(),
+        });
+    }
+    if grant_types.is_empty() {
+        return Err(AmiError::InvalidParameter {
+            message: "a client with no grant types can never obtain a token".to_string(),
+        });
+    }
+
+    Ok(OAuthClient {
+        client_id,
+        secret_hash: crate::service::auth::hash_secret(plaintext_secret)?,
+        name,
+        grant_types,
+        scopes,
+        audience,
+        created_at: Utc::now(),
+        enabled: true,
+    })
+}
+
+/// Generate a client secret with 256 bits of entropy.
+pub fn generate_client_secret() -> String {
+    Uuid::new_v4().simple().to_string() + &Uuid::new_v4().simple().to_string()
+}
+
+/// Build the claims for an access token.
+pub fn build_claims(
+    client: &OAuthClient,
+    scopes: &[String],
+    issuer: &str,
+    issued_at: DateTime<Utc>,
+    lifetime: Duration,
+) -> OAuthClaims {
+    OAuthClaims {
+        sub: client.client_id.clone(),
+        iss: issuer.to_string(),
+        aud: client.audience.clone(),
+        exp: (issued_at + lifetime).timestamp(),
+        iat: issued_at.timestamp(),
+        jti: Uuid::new_v4().to_string(),
+        scope: scopes.join(" "),
+        client_id: client.client_id.clone(),
+    }
+}
+
+/// The record kept so the token can later be revoked.
+pub fn build_token_record(claims: &OAuthClaims, issued_at: DateTime<Utc>) -> AccessToken {
+    AccessToken {
+        jti: claims.jti.clone(),
+        client_id: claims.client_id.clone(),
+        scopes: if claims.scope.is_empty() {
+            vec![]
+        } else {
+            claims.scope.split(' ').map(str::to_string).collect()
+        },
+        issued_at,
+        expires_at: DateTime::from_timestamp(claims.exp, 0).unwrap_or(issued_at),
+        revoked_at: None,
+    }
+}
+
+/// Wrap a signed token in the RFC 6749 §5.1 response shape.
+pub fn build_response(
+    access_token: String,
+    scopes: &[String],
+    lifetime: Duration,
+) -> TokenResponse {
+    TokenResponse {
+        access_token,
+        token_type: "Bearer".to_string(),
+        expires_in: lifetime.num_seconds(),
+        scope: scopes.join(" "),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_client_secret_is_never_stored_in_the_clear() {
+        let client = build_client(
+            "svc".into(),
+            "hunter2",
+            "Service".into(),
+            vec![GrantType::ClientCredentials],
+            vec!["read".into()],
+            "wami".into(),
+        )
+        .unwrap();
+
+        assert_ne!(client.secret_hash, "hunter2");
+        assert!(crate::service::auth::verify_secret("hunter2", &client.secret_hash).unwrap());
+        assert!(!crate::service::auth::verify_secret("wrong", &client.secret_hash).unwrap());
+    }
+
+    #[test]
+    fn a_client_that_could_never_get_a_token_is_refused_at_registration() {
+        let err = build_client(
+            "svc".into(),
+            "s",
+            "Service".into(),
+            vec![],
+            vec![],
+            "wami".into(),
+        )
+        .unwrap_err();
+        assert!(matches!(err, AmiError::InvalidParameter { .. }));
+    }
+
+    #[test]
+    fn an_empty_id_or_secret_is_refused() {
+        for (id, secret) in [("", "s"), ("  ", "s"), ("svc", "")] {
+            assert!(build_client(
+                id.into(),
+                secret,
+                "n".into(),
+                vec![GrantType::ClientCredentials],
+                vec![],
+                "wami".into(),
+            )
+            .is_err());
+        }
+    }
+
+    #[test]
+    fn secrets_do_not_repeat() {
+        let a = generate_client_secret();
+        let b = generate_client_secret();
+        assert_ne!(a, b);
+        assert_eq!(a.len(), 64, "256 bits of hex");
+    }
+
+    #[test]
+    fn every_token_gets_its_own_id_so_revocation_is_per_token() {
+        let client = build_client(
+            "svc".into(),
+            "s",
+            "Service".into(),
+            vec![GrantType::ClientCredentials],
+            vec!["read".into()],
+            "wami".into(),
+        )
+        .unwrap();
+        let now = Utc::now();
+        let first = build_claims(
+            &client,
+            &["read".into()],
+            "wami",
+            now,
+            Duration::minutes(15),
+        );
+        let second = build_claims(
+            &client,
+            &["read".into()],
+            "wami",
+            now,
+            Duration::minutes(15),
+        );
+
+        assert_ne!(
+            first.jti, second.jti,
+            "a shared jti would revoke both at once"
+        );
+        assert_eq!(first.exp - first.iat, 900);
+        assert_eq!(first.scope, "read");
+    }
+
+    #[test]
+    fn a_token_record_round_trips_its_scopes() {
+        let client = build_client(
+            "svc".into(),
+            "s",
+            "Service".into(),
+            vec![GrantType::ClientCredentials],
+            vec!["read".into(), "write".into()],
+            "wami".into(),
+        )
+        .unwrap();
+        let now = Utc::now();
+        let claims = build_claims(
+            &client,
+            &["read".into(), "write".into()],
+            "wami",
+            now,
+            Duration::minutes(15),
+        );
+        let record = build_token_record(&claims, now);
+
+        assert_eq!(record.scopes, vec!["read", "write"]);
+        assert_eq!(record.jti, claims.jti);
+        assert!(record.revoked_at.is_none());
+
+        // A scopeless token must not produce a single empty-string scope.
+        let bare = build_claims(&client, &[], "wami", now, Duration::minutes(15));
+        assert!(build_token_record(&bare, now).scopes.is_empty());
+    }
+}

--- a/crates/wami/src/wami/oauth/mod.rs
+++ b/crates/wami/src/wami/oauth/mod.rs
@@ -1,0 +1,26 @@
+//! OAuth 2.0 — machine-to-machine token issuance.
+//!
+//! wami as the authorization server for the `client_credentials` grant: a
+//! service authenticates as itself and receives a signed, short-lived JWT.
+//!
+//! Tokens are signed by the same [`KeyManager`] that signs STS credentials, so
+//! there is one keyset, one rotation policy, and one JWKS to publish. They are
+//! verifiable offline; the store exists so they can be revoked before they
+//! expire.
+//!
+//! The flows that involve a human — authorization code, PKCE, consent, ID
+//! tokens — are a separate concern and are not here.
+//!
+//! [`KeyManager`]: crate::wami::sts::jwt::KeyManager
+
+pub mod builder;
+pub mod model;
+
+pub use builder::{
+    build_claims, build_client, build_response, build_token_record, generate_client_secret,
+    DEFAULT_TOKEN_LIFETIME,
+};
+pub use model::{
+    AccessToken, GrantRequest, GrantType, OAuthClaims, OAuthClient, TokenIntrospection,
+    TokenResponse,
+};

--- a/crates/wami/src/wami/oauth/model.rs
+++ b/crates/wami/src/wami/oauth/model.rs
@@ -1,0 +1,277 @@
+//! OAuth 2.0 domain types.
+//!
+//! Machine-to-machine only: a service presents credentials and gets a token.
+//! The flows that involve a human — authorization code, PKCE, consent — need
+//! redirects and replay protection, and live elsewhere.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+
+/// How a client is allowed to obtain a token.
+///
+/// Only `client_credentials` is honoured today. The variant is an enum rather
+/// than a bare string so that registering a client for a grant the library
+/// cannot yet perform is a type error, not a runtime surprise.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GrantType {
+    /// The client authenticates as itself. No user is involved.
+    ClientCredentials,
+}
+
+/// A registered OAuth client.
+///
+/// The secret is stored hashed, like every other credential in this library —
+/// see [`OAuthClient::secret_hash`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthClient {
+    /// Public identifier, safe to log.
+    pub client_id: String,
+    /// bcrypt hash of the secret. Never the secret itself.
+    pub secret_hash: String,
+    /// Human-readable name, for operators reading a client list.
+    pub name: String,
+    /// Grants this client may use.
+    pub grant_types: Vec<GrantType>,
+    /// Scopes this client may ask for. A request for anything outside this set
+    /// is refused rather than silently narrowed — a client that believes it
+    /// holds a scope it does not is worse than one told it cannot have it.
+    pub scopes: Vec<String>,
+    /// The audience tokens for this client are minted with.
+    pub audience: String,
+    /// When the client was registered.
+    pub created_at: DateTime<Utc>,
+    /// Whether the client may still obtain tokens.
+    pub enabled: bool,
+}
+
+impl OAuthClient {
+    /// Whether this client is allowed to use `grant`.
+    pub fn allows_grant(&self, grant: GrantType) -> bool {
+        self.grant_types.contains(&grant)
+    }
+
+    /// The subset of `requested` this client may have, or the first scope it
+    /// may not.
+    ///
+    /// An empty request means "everything you are entitled to", matching
+    /// RFC 6749 §3.3, where an omitted scope leaves the choice to the server.
+    pub fn narrow_scopes<'a>(&self, requested: &'a [String]) -> Result<Vec<String>, &'a str> {
+        if requested.is_empty() {
+            return Ok(self.scopes.clone());
+        }
+        if let Some(refused) = requested.iter().find(|s| !self.scopes.contains(s)) {
+            return Err(refused);
+        }
+        Ok(requested.to_vec())
+    }
+}
+
+/// What a caller asks for when it wants a token.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum GrantRequest {
+    /// RFC 6749 §4.4 — the client authenticates as itself.
+    ClientCredentials {
+        /// The client's public identifier.
+        client_id: String,
+        /// The client's secret, in the clear, checked against the stored hash.
+        client_secret: String,
+        /// Scopes asked for. Empty means every scope the client holds.
+        scope: Vec<String>,
+    },
+}
+
+/// The claims carried by an OAuth access token.
+///
+/// Deliberately separate from `StsClaims`: the two are signed by the same keys
+/// but answer to different specifications, and merging them would mean every
+/// STS change had to be checked against RFC 7662.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OAuthClaims {
+    /// Subject — the client, since no user is involved in this grant.
+    pub sub: String,
+    /// Issuer.
+    pub iss: String,
+    /// Audience.
+    pub aud: String,
+    /// Expiry, as a Unix timestamp.
+    pub exp: i64,
+    /// Issue time, as a Unix timestamp.
+    pub iat: i64,
+    /// Token id. This is what revocation records, so it must be unique per
+    /// token rather than per client.
+    pub jti: String,
+    /// Granted scopes, space-delimited as RFC 6749 §3.3 requires.
+    #[serde(default, skip_serializing_if = "String::is_empty")]
+    pub scope: String,
+    /// The client that obtained the token. Redundant with `sub` for this grant,
+    /// and not for the ones that will follow — a token obtained on behalf of a
+    /// user has a user as `sub` and still needs to name the client.
+    pub client_id: String,
+}
+
+/// A token as it was issued, for the store to keep.
+///
+/// The signed JWT is verifiable offline, so this record exists for exactly one
+/// reason: revocation. A signed token stays valid until it expires unless
+/// something is asked, and this is the thing that gets asked.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AccessToken {
+    /// The `jti` of the token, and the key it is revoked by.
+    pub jti: String,
+    /// Which client holds it.
+    pub client_id: String,
+    /// What it grants.
+    pub scopes: Vec<String>,
+    /// When it was issued.
+    pub issued_at: DateTime<Utc>,
+    /// When it stops being valid on its own.
+    pub expires_at: DateTime<Utc>,
+    /// When it was revoked, if it was.
+    pub revoked_at: Option<DateTime<Utc>>,
+}
+
+impl AccessToken {
+    /// Whether the token is still usable at `now`.
+    pub fn is_active_at(&self, now: DateTime<Utc>) -> bool {
+        self.revoked_at.is_none() && self.expires_at > now
+    }
+}
+
+/// The response to a successful token request — RFC 6749 §5.1.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenResponse {
+    /// The signed JWT.
+    pub access_token: String,
+    /// Always `Bearer` here.
+    pub token_type: String,
+    /// Lifetime in seconds, as the RFC specifies — not an absolute time.
+    pub expires_in: i64,
+    /// Granted scopes, space-delimited. May be narrower than requested.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub scope: String,
+}
+
+/// The answer to an introspection request — RFC 7662 §2.2.
+///
+/// Every field but `active` is absent when the token is not active. The RFC is
+/// explicit about this: an inactive token must not leak who it belonged to.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct TokenIntrospection {
+    /// Whether the token is currently valid.
+    pub active: bool,
+    /// Granted scopes, space-delimited.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub scope: Option<String>,
+    /// The client the token was issued to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub client_id: Option<String>,
+    /// Subject.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sub: Option<String>,
+    /// Expiry, as a Unix timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exp: Option<i64>,
+    /// Issue time, as a Unix timestamp.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iat: Option<i64>,
+    /// Token id.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub jti: Option<String>,
+}
+
+impl TokenIntrospection {
+    /// The answer for a token that is expired, revoked, forged, or unknown.
+    ///
+    /// One shape for all four on purpose: telling them apart would let an
+    /// attacker probe for which token ids exist.
+    pub fn inactive() -> Self {
+        Self {
+            active: false,
+            scope: None,
+            client_id: None,
+            sub: None,
+            exp: None,
+            iat: None,
+            jti: None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn client(scopes: &[&str]) -> OAuthClient {
+        OAuthClient {
+            client_id: "c".into(),
+            secret_hash: "h".into(),
+            name: "n".into(),
+            grant_types: vec![GrantType::ClientCredentials],
+            scopes: scopes.iter().map(|s| s.to_string()).collect(),
+            audience: "wami".into(),
+            created_at: Utc::now(),
+            enabled: true,
+        }
+    }
+
+    #[test]
+    fn an_empty_scope_request_means_everything_the_client_holds() {
+        let c = client(&["read", "write"]);
+        assert_eq!(c.narrow_scopes(&[]).unwrap(), vec!["read", "write"]);
+    }
+
+    #[test]
+    fn a_scope_the_client_does_not_hold_is_refused_not_dropped() {
+        // Silently narrowing would hand back a token the caller believes is
+        // broader than it is — the failure would surface later, elsewhere.
+        let c = client(&["read"]);
+        let asked = vec!["read".to_string(), "write".to_string()];
+        assert_eq!(c.narrow_scopes(&asked), Err("write"));
+    }
+
+    #[test]
+    fn a_subset_is_granted_as_asked() {
+        let c = client(&["read", "write"]);
+        let asked = vec!["read".to_string()];
+        assert_eq!(c.narrow_scopes(&asked).unwrap(), vec!["read"]);
+    }
+
+    #[test]
+    fn a_revoked_token_is_inactive_even_before_it_expires() {
+        let now = Utc::now();
+        let mut token = AccessToken {
+            jti: "j".into(),
+            client_id: "c".into(),
+            scopes: vec![],
+            issued_at: now,
+            expires_at: now + chrono::Duration::hours(1),
+            revoked_at: None,
+        };
+        assert!(token.is_active_at(now));
+
+        token.revoked_at = Some(now);
+        assert!(!token.is_active_at(now));
+    }
+
+    #[test]
+    fn an_expired_token_is_inactive_even_though_it_was_never_revoked() {
+        let now = Utc::now();
+        let token = AccessToken {
+            jti: "j".into(),
+            client_id: "c".into(),
+            scopes: vec![],
+            issued_at: now - chrono::Duration::hours(2),
+            expires_at: now - chrono::Duration::hours(1),
+            revoked_at: None,
+        };
+        assert!(!token.is_active_at(now));
+    }
+
+    #[test]
+    fn an_inactive_introspection_reveals_nothing_else() {
+        // RFC 7662: an inactive token must not disclose who held it.
+        let json = serde_json::to_value(TokenIntrospection::inactive()).unwrap();
+        assert_eq!(json, serde_json::json!({ "active": false }));
+    }
+}

--- a/crates/wami/src/wami/sts/jwt.rs
+++ b/crates/wami/src/wami/sts/jwt.rs
@@ -13,6 +13,7 @@ use ed25519_dalek::pkcs8::EncodePrivateKey;
 use ed25519_dalek::{SigningKey, VerifyingKey};
 use jsonwebtoken::{decode, encode, Algorithm, DecodingKey, EncodingKey, Header, Validation};
 use rand::rngs::OsRng;
+use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
 
@@ -240,7 +241,10 @@ impl KeyManager {
     /// invalidate every token still in flight.
     ///
     /// Uses standard PKCS#8 DER encoding for the Ed25519 signing key.
-    pub fn sign_claims(&self, claims: &StsClaims) -> Result<String, JwtError> {
+    /// Generic over the claim set so other issuers — OAuth, for one — can sign
+    /// with the same keys and the same rotation, instead of each growing its own
+    /// signer. Existing callers infer `StsClaims` from the argument.
+    pub fn sign_claims<C: Serialize>(&self, claims: &C) -> Result<String, JwtError> {
         let mut header = Header::new(Algorithm::EdDSA);
         header.kid = Some(self.active.kid.clone());
         let pkcs8_der = self
@@ -262,6 +266,19 @@ impl KeyManager {
     /// Note: `jsonwebtoken` with the `ring` backend expects raw 32-byte Ed25519
     /// public keys via `from_ed_der` (despite the function name suggesting DER).
     pub fn verify_token(&self, token: &str, audience: &str) -> Result<StsClaims, JwtError> {
+        self.verify_claims(token, audience)
+    }
+
+    /// Verify a token and deserialise it into any claim set.
+    ///
+    /// [`KeyManager::verify_token`] is this with `StsClaims` filled in; the two
+    /// share every check, so key rotation and audience validation cannot drift
+    /// apart between issuers.
+    pub fn verify_claims<C: DeserializeOwned>(
+        &self,
+        token: &str,
+        audience: &str,
+    ) -> Result<C, JwtError> {
         // Which key signed this is read from the header before anything is
         // verified. An unknown or absent kid is refused as such, and not as a
         // bad signature: the two are diagnosed differently — one is a key
@@ -283,7 +300,7 @@ impl KeyManager {
         validation.set_audience(&[audience]);
         // validate_aud defaults to true and set_audience configures the expected
         // values — audience IS validated.
-        let token_data = decode::<StsClaims>(token, &decoding_key, &validation).map_err(|e| {
+        let token_data = decode::<C>(token, &decoding_key, &validation).map_err(|e| {
             // A well-signed token addressed elsewhere is not a forgery: it is a
             // token of the wrong class, and the caller has to distinguish the
             // two to route or refuse it. Collapsing it into `Decode` would make


### PR DESCRIPTION
Closes #118.

wami as an OAuth 2.0 authorization server for the `client_credentials` grant: a service authenticates as itself and receives a short-lived signed JWT. No human, no redirect, no consent — those need replay protection and a consent record, and are #119.

## One keyset, not two

Tokens are signed by the same `KeyManager` that signs STS credentials, so there is one rotation policy and one JWKS to publish for both.

That needed `sign_claims` to stop being `StsClaims`-shaped. It and the new `verify_claims` are now generic over the claim set, with `verify_token` kept as the concrete STS wrapper — **existing callers are untouched**, inference does the work. Every check (key id lookup, retired keys, audience) is shared, so the two issuers cannot drift apart.

`OAuthClaims` stays separate from `StsClaims` deliberately: they answer to different specifications, and merging them would mean checking every STS change against RFC 7662.

## Why there is a store at all

Everything here could be stateless except revocation. A signed token is valid until its `exp` no matter what the issuer later decides, so revoking one means recording it — that is the entire reason `OAuthTokenStore` exists, and why the default lifetime is 15 minutes rather than hours.

The limit is documented rather than papered over: **revocation binds on whoever introspects**, and a verifier checking the signature offline keeps accepting a revoked token until it expires. Anything with immediate cost should introspect rather than verify locally.

## Decisions worth stating

- **Every authentication failure looks identical.** Unknown client, wrong secret, disabled client — same error, same message. Distinguishing them would make the endpoint an oracle for which client ids exist. A test asserts the three messages are byte-identical.
- **An inactive token discloses nothing else.** RFC 7662 is explicit; the test asserts the serialised body is exactly `{"active": false}`.
- **Revoking an unknown token succeeds** (RFC 7009): the caller must not learn whether it ever existed.
- **A scope the client does not hold is refused, not dropped.** Silently narrowing would hand back a token the caller believes is broader than it is, and the failure would surface somewhere else entirely.

## The naming question #118 raised, settled

`ConsentStore` is already taken by GDPR — and I found `SessionStore` is taken by STS too, so #119 would have had **two** collisions, not one. Every OAuth trait carries the `OAuth` prefix: `OAuthClientStore`, `OAuthTokenStore`. Prefixing now costs nothing; renaming once consumers have implemented against them is not free.

## Scope

Purely additive — a new `oauth` domain, two store traits, an in-memory implementation, and `OAuthService`. **No existing signature changes**; the `KeyManager` generalisation is source-compatible.

## Verification

- **1519 tests, 0 failures** across the workspace (29 new, doctests included)
- clippy silent, fmt clean
- **Example 27** runs the whole path end to end — registration, offline JWKS verification, scope refusal, introspection, revocation, and containing a compromised client in two moves
- The same five pre-existing example failures as on `main`, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)