### PR TITLE
feat(oauth)!: explicit token typing (RFC 9068) and authentication-event claims

### DIFF
--- a/crates/wami/examples/28_oidc_authorization_code.rs
+++ b/crates/wami/examples/28_oidc_authorization_code.rs
@@ -34,7 +34,7 @@ use wami::wami::oauth::{
     build_client, derive_s256_challenge, generate_client_secret, AuthenticationEvent,
     CodeChallenge, GrantType, IdTokenClaims, OAuthClaims, UserProfile,
 };
-use wami::wami::sts::jwt::{KeyManager, TokenType};
+use wami::wami::sts::jwt::{KeyManager, TokenType, TypePolicy};
 use wami_core::error::Result;
 
 const AUDIENCE: &str = "photos-api";
@@ -177,10 +177,15 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         id.email
     );
 
-    // A verifier of access tokens has to say so, now that they are labelled.
-    // `verify_claims` is the ID-token-shaped door and refuses an `at+jwt`.
-    let access: OAuthClaims =
-        keys.verify_claims_as(&tokens.access_token, AUDIENCE, TokenType::AccessToken)?;
+    // Strict, because this deployment labels everything it issues — RFC 9068
+    // §4 as written. A resource server still accepting tokens from an issuer
+    // that has not migrated would pass `TypePolicy::Lenient` instead.
+    let access: OAuthClaims = keys.verify_claims_as(
+        &tokens.access_token,
+        AUDIENCE,
+        TokenType::AccessToken,
+        TypePolicy::Strict,
+    )?;
     println!("   Access token → what may be done");
     println!("      sub={} client_id={}", access.sub, access.client_id);
     println!("      scope={}", access.scope);
@@ -199,6 +204,18 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         "   headers say typ={:?} (access) vs {:?} (id)",
         jsonwebtoken::decode_header(&tokens.access_token)?.typ,
         jsonwebtoken::decode_header(tokens.id_token.as_ref().unwrap())?.typ,
+    );
+
+    // The label refuses it on its own, with the audience held right.
+    let mislabelled: std::result::Result<IdTokenClaims, _> = keys.verify_claims_as(
+        &tokens.access_token,
+        AUDIENCE,
+        TokenType::Jwt,
+        TypePolicy::Lenient,
+    );
+    println!(
+        "   and the label alone refuses it as an ID token: {}",
+        mislabelled.is_err()
     );
 
     let info = service.user_info(&tokens.access_token, AUDIENCE).await?;

--- a/crates/wami/examples/28_oidc_authorization_code.rs
+++ b/crates/wami/examples/28_oidc_authorization_code.rs
@@ -14,9 +14,15 @@
 //! 6. Withdrawing consent
 //! 7. The discovery document
 //!
+//! Two things the host opts into, shown along the way: reporting *how* it
+//! authenticated the user (`auth_time`/`acr`/`amr`), and labelling access
+//! tokens `at+jwt` so a resource server can refuse an ID token structurally
+//! rather than by checking the audience.
+//!
 //! wami does not authenticate the user. The host does that — a password, a
 //! passkey, an upstream IdP — and then tells wami who signed in.
 
+use chrono::{Duration, Utc};
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use wami::service::oauth::oidc::{
@@ -25,10 +31,10 @@ use wami::service::oauth::oidc::{
 use wami::service::oauth::OAuthService;
 use wami::store::memory::InMemoryOAuthStore;
 use wami::wami::oauth::{
-    build_client, derive_s256_challenge, generate_client_secret, CodeChallenge, GrantType,
-    IdTokenClaims, OAuthClaims, UserProfile,
+    build_client, derive_s256_challenge, generate_client_secret, AuthenticationEvent,
+    CodeChallenge, GrantType, IdTokenClaims, OAuthClaims, UserProfile,
 };
-use wami::wami::sts::jwt::KeyManager;
+use wami::wami::sts::jwt::{KeyManager, TokenType};
 use wami_core::error::Result;
 
 const AUDIENCE: &str = "photos-api";
@@ -58,7 +64,10 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     let store = Arc::new(RwLock::new(InMemoryOAuthStore::new()));
     let keys = Arc::new(KeyManager::generate());
     let service = OAuthService::new(store, keys.clone(), "https://id.example.test".to_string())
-        .with_user_claims(Arc::new(Directory));
+        .with_user_claims(Arc::new(Directory))
+        // RFC 9068: access tokens get `typ: at+jwt`, ID tokens keep `JWT`.
+        // Opt-in, because a resource server pinning the old value would break.
+        .with_explicit_typ();
 
     let secret = generate_client_secret();
     let client = build_client(
@@ -88,6 +97,15 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         "profile".to_string(),
         "photos:read".to_string(),
     ];
+    // The host authenticated Alice two hours ago with a password and a
+    // hardware key, and is willing to say so. wami cannot know this — it never
+    // performs the sign-in.
+    let signed_in = AuthenticationEvent {
+        at: Utc::now() - Duration::hours(2),
+        acr: Some("urn:mace:incommon:iap:silver".to_string()),
+        amr: vec!["pwd".to_string(), "hwk".to_string()],
+    };
+
     let request = || AuthorizationRequest {
         client_id: "gallery".to_string(),
         user_name: "alice".to_string(), // the host has just authenticated her
@@ -95,6 +113,7 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         scopes: asked.clone(),
         challenge: challenge.clone(),
         nonce: Some("n-0S6_WzA2Mj".to_string()),
+        event: Some(signed_in.clone()),
         state: Some("opaque-client-state".to_string()),
     };
 
@@ -152,23 +171,34 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
     println!("   ID token   → who signed in");
     println!("      sub={} name={:?}", id.sub, id.name);
     println!("      nonce echoed: {:?}", id.nonce);
+    println!("      acr={:?} amr={:?}", id.acr, id.amr);
     println!(
         "      email={:?} (the `email` scope was never asked for)",
         id.email
     );
 
-    let access: OAuthClaims = keys.verify_claims(&tokens.access_token, AUDIENCE)?;
+    // A verifier of access tokens has to say so, now that they are labelled.
+    // `verify_claims` is the ID-token-shaped door and refuses an `at+jwt`.
+    let access: OAuthClaims =
+        keys.verify_claims_as(&tokens.access_token, AUDIENCE, TokenType::AccessToken)?;
     println!("   Access token → what may be done");
     println!("      sub={} client_id={}", access.sub, access.client_id);
     println!("      scope={}", access.scope);
 
-    // The two audiences are why a resource server cannot mistake one for the
-    // other: an ID token simply does not verify against the API's audience.
+    // Two independent barriers. The audiences differ, so an ID token does not
+    // verify against the API's audience — and with explicit typing on, the
+    // header says `at+jwt` vs `JWT`, which a resource server can refuse without
+    // looking at a single claim.
     let confused: std::result::Result<IdTokenClaims, _> =
         keys.verify_claims(tokens.id_token.as_ref().unwrap(), AUDIENCE);
     println!(
         "✅ the API refuses the ID token as authorisation: {}",
         confused.is_err()
+    );
+    println!(
+        "   headers say typ={:?} (access) vs {:?} (id)",
+        jsonwebtoken::decode_header(&tokens.access_token)?.typ,
+        jsonwebtoken::decode_header(tokens.id_token.as_ref().unwrap())?.typ,
     );
 
     let info = service.user_info(&tokens.access_token, AUDIENCE).await?;
@@ -181,6 +211,18 @@ async fn main() -> std::result::Result<(), Box<dyn std::error::Error>> {
         .refresh_tokens("gallery", &secret, &tokens.refresh_token)
         .await?;
     println!("✅ refreshed — the old token is spent, a new one took its place");
+
+    // OIDC Core §12.2: auth_time is the ORIGINAL sign-in, not this moment.
+    let refreshed: IdTokenClaims =
+        keys.verify_claims(next.id_token.as_ref().unwrap(), "gallery")?;
+    println!(
+        "   auth_time unchanged: {} — the session did not get younger",
+        if refreshed.auth_time == Some(signed_in.at.timestamp()) {
+            "yes"
+        } else {
+            "NO — §12.2 violated!"
+        }
+    );
 
     // Someone stole the first refresh token and tries it after the client used
     // it. There is no way to tell the thief from the client, so both lose.

--- a/crates/wami/src/service/oauth/mod.rs
+++ b/crates/wami/src/service/oauth/mod.rs
@@ -82,6 +82,9 @@ pub struct OAuthService<S> {
     lifetime: Duration,
     /// Where ID token profile claims come from. `None` releases only `sub`.
     user_claims: Option<Arc<dyn oidc::UserClaimsSource>>,
+    /// Whether access tokens declare `typ: at+jwt`. Off, for now — see
+    /// [`OAuthService::with_explicit_typ`].
+    explicit_typ: bool,
 }
 
 impl<S: OAuthStore> OAuthService<S> {
@@ -93,6 +96,7 @@ impl<S: OAuthStore> OAuthService<S> {
             issuer,
             lifetime: DEFAULT_TOKEN_LIFETIME,
             user_claims: None,
+            explicit_typ: false,
         }
     }
 
@@ -103,6 +107,46 @@ impl<S: OAuthStore> OAuthService<S> {
     pub fn with_token_lifetime(mut self, lifetime: Duration) -> Self {
         self.lifetime = lifetime;
         self
+    }
+
+    /// Label access tokens `typ: at+jwt`, per RFC 9068.
+    ///
+    /// # What it buys
+    ///
+    /// wami tells an access token from an ID token by `aud`, and that holds —
+    /// but only for a verifier that checks the audience. RFC 9068 adds a
+    /// header a resource server can refuse on directly:
+    ///
+    /// > The resource server MUST verify that the `typ` header value is
+    /// > `at+jwt` or `application/at+jwt` and reject tokens carrying any other
+    /// > value.
+    ///
+    /// ID tokens are unaffected: OIDC registers no `typ` of its own for them,
+    /// so they keep `JWT`. That difference is the point — once this is on,
+    /// nothing wami signs as an access token can be read as an ID token.
+    ///
+    /// # Why it is opt-in
+    ///
+    /// Every token issued before this existed carries `typ: JWT`, and a
+    /// resource server that pins that value would start refusing new tokens the
+    /// moment the header changed. Turning this on is therefore a decision for
+    /// the deployment, not a default — and it is safe to make mid-flight:
+    /// verification accepts either label on an access token, so tokens already
+    /// in circulation keep working until they expire. Nothing is reissued.
+    ///
+    /// The default flips at the next major.
+    pub fn with_explicit_typ(mut self) -> Self {
+        self.explicit_typ = true;
+        self
+    }
+
+    /// The `typ` this service signs access tokens with.
+    pub(crate) fn access_token_type(&self) -> crate::wami::sts::jwt::TokenType {
+        if self.explicit_typ {
+            crate::wami::sts::jwt::TokenType::AccessToken
+        } else {
+            crate::wami::sts::jwt::TokenType::Jwt
+        }
     }
 
     /// The public keys a verifier needs, as a JWKS.
@@ -177,7 +221,7 @@ impl<S: OAuthStore> OAuthService<S> {
             builder::build_claims(&client, &granted, &self.issuer, issued_at, self.lifetime);
         let signed = self
             .keys
-            .sign_claims(&claims)
+            .sign_claims_as(&claims, self.access_token_type())
             .map_err(|e| AmiError::StoreError(format!("failed to sign token: {e}")))?;
 
         // Recorded before it is handed out: a token the caller holds but the
@@ -201,7 +245,11 @@ impl<S: OAuthStore> OAuthService<S> {
         token: &str,
         audience: &str,
     ) -> Result<TokenIntrospection> {
-        let Ok(claims) = self.keys.verify_claims::<OAuthClaims>(token, audience) else {
+        let Ok(claims) = self.keys.verify_claims_as::<OAuthClaims>(
+            token,
+            audience,
+            crate::wami::sts::jwt::TokenType::AccessToken,
+        ) else {
             return Ok(TokenIntrospection::inactive());
         };
 
@@ -235,7 +283,11 @@ impl<S: OAuthStore> OAuthService<S> {
     /// offline will keep accepting the token until it expires. Revocation binds
     /// on anyone who introspects, which is why token lifetimes are short.
     pub async fn revoke_token(&self, token: &str, audience: &str) -> Result<()> {
-        if let Ok(claims) = self.keys.verify_claims::<OAuthClaims>(token, audience) {
+        if let Ok(claims) = self.keys.verify_claims_as::<OAuthClaims>(
+            token,
+            audience,
+            crate::wami::sts::jwt::TokenType::AccessToken,
+        ) {
             self.store
                 .write()
                 .await

--- a/crates/wami/src/service/oauth/mod.rs
+++ b/crates/wami/src/service/oauth/mod.rs
@@ -245,10 +245,14 @@ impl<S: OAuthStore> OAuthService<S> {
         token: &str,
         audience: &str,
     ) -> Result<TokenIntrospection> {
+        // Lenient: this service introspects its own tokens, and some of them
+        // may predate `with_explicit_typ`. Refusing those would make flipping
+        // the flag an outage.
         let Ok(claims) = self.keys.verify_claims_as::<OAuthClaims>(
             token,
             audience,
             crate::wami::sts::jwt::TokenType::AccessToken,
+            crate::wami::sts::jwt::TypePolicy::Lenient,
         ) else {
             return Ok(TokenIntrospection::inactive());
         };
@@ -287,6 +291,7 @@ impl<S: OAuthStore> OAuthService<S> {
             token,
             audience,
             crate::wami::sts::jwt::TokenType::AccessToken,
+            crate::wami::sts::jwt::TypePolicy::Lenient,
         ) {
             self.store
                 .write()

--- a/crates/wami/src/service/oauth/oidc.rs
+++ b/crates/wami/src/service/oauth/oidc.rs
@@ -38,7 +38,7 @@ use crate::wami::oauth::{
     GrantType, OAuthClaims, OAuthClient, RefreshToken, UserConsent, UserInfo, UserProfile,
     AUTHORIZATION_CODE_LIFETIME, REFRESH_TOKEN_LIFETIME,
 };
-use crate::wami::sts::jwt::TokenType;
+use crate::wami::sts::jwt::{TokenType, TypePolicy};
 
 /// Combined bound for a store that can serve the user-facing flows.
 pub trait OidcStore:
@@ -450,7 +450,12 @@ impl<S: OidcStore> OAuthService<S> {
 
         let claims = self
             .keys
-            .verify_claims_as::<OAuthClaims>(access_token, audience, TokenType::AccessToken)
+            .verify_claims_as::<OAuthClaims>(
+                access_token,
+                audience,
+                TokenType::AccessToken,
+                TypePolicy::Lenient,
+            )
             .map_err(|_| refused())?;
 
         let scopes: Vec<String> = claims
@@ -1382,12 +1387,29 @@ mod tests {
         let id = jsonwebtoken::decode_header(tokens.id_token.as_ref().unwrap()).unwrap();
         assert_eq!(id.typ.as_deref(), Some("JWT"));
 
+        // Two independent barriers, checked one at a time. The audience: an
+        // access token names the API, so it does not verify against the
+        // client. And the label, isolated by asking with the *right* audience
+        // — only the `typ` can refuse it here.
         assert!(
             service
                 .keys
                 .verify_claims::<IdTokenClaims>(&tokens.access_token, "app")
                 .is_err(),
-            "a labelled access token must not pass as an ID token"
+            "the audience alone should have refused it"
+        );
+        let by_label = service.keys.verify_claims_as::<IdTokenClaims>(
+            &tokens.access_token,
+            AUD,
+            TokenType::Jwt,
+            TypePolicy::Lenient,
+        );
+        assert!(
+            matches!(
+                by_label,
+                Err(crate::wami::sts::jwt::JwtError::TokenTypeMismatch { .. })
+            ),
+            "the label alone should have refused it, got {by_label:?}"
         );
     }
 

--- a/crates/wami/src/service/oauth/oidc.rs
+++ b/crates/wami/src/service/oauth/oidc.rs
@@ -34,10 +34,11 @@ use wami_core::error::{AmiError, Result};
 use super::{OAuthService, OAuthStore};
 use crate::store::traits::oauth::{OAuthAuthorizationStore, OAuthConsentStore, OAuthRefreshStore};
 use crate::wami::oauth::{
-    builder, oidc, AuthorizationCode, CodeChallenge, DiscoveryDocument, GrantType, OAuthClaims,
-    OAuthClient, RefreshToken, UserConsent, UserInfo, UserProfile, AUTHORIZATION_CODE_LIFETIME,
-    REFRESH_TOKEN_LIFETIME,
+    builder, oidc, AuthenticationEvent, AuthorizationCode, CodeChallenge, DiscoveryDocument,
+    GrantType, OAuthClaims, OAuthClient, RefreshToken, UserConsent, UserInfo, UserProfile,
+    AUTHORIZATION_CODE_LIFETIME, REFRESH_TOKEN_LIFETIME,
 };
+use crate::wami::sts::jwt::TokenType;
 
 /// Combined bound for a store that can serve the user-facing flows.
 pub trait OidcStore:
@@ -86,6 +87,12 @@ pub struct AuthorizationRequest {
     pub challenge: CodeChallenge,
     /// The client's nonce, echoed into the ID token.
     pub nonce: Option<String>,
+    /// What the host did to authenticate the user, if it wants to say.
+    ///
+    /// Produces `auth_time`, `acr` and `amr` in the ID token, and survives into
+    /// the refresh chain so a later token reports the *original* sign-in.
+    /// Omitting it omits those claims; nothing else changes.
+    pub event: Option<AuthenticationEvent>,
     /// The client's opaque state, handed back untouched.
     ///
     /// wami does nothing with it, and cannot: `state` defends against CSRF by
@@ -231,6 +238,7 @@ impl<S: OidcStore> OAuthService<S> {
             redirect_uri: request.redirect_uri.clone(),
             challenge: Some(request.challenge),
             nonce: request.nonce,
+            event: request.event,
             expires_at: Utc::now() + AUTHORIZATION_CODE_LIFETIME,
         };
         let issued = code.code.clone();
@@ -339,8 +347,14 @@ impl<S: OidcStore> OAuthService<S> {
             _ => return Err(refused_code()),
         }
 
-        self.mint(&client, &code.user_name, &code.scopes, code.nonce)
-            .await
+        self.mint(
+            &client,
+            &code.user_name,
+            &code.scopes,
+            code.nonce,
+            code.event,
+        )
+        .await
     }
 
     /// Exchange a refresh token for a fresh set.
@@ -384,6 +398,7 @@ impl<S: OidcStore> OAuthService<S> {
             expires_at: Utc::now() + REFRESH_TOKEN_LIFETIME,
             used_at: None,
             replaced_by: None,
+            event: existing.event.clone(),
         };
         let minted = replacement.token.clone();
 
@@ -417,7 +432,7 @@ impl<S: OidcStore> OAuthService<S> {
         // the original authentication contained nonce". The nonce belonged to
         // one sign-in; replaying it into a later token would defeat what the
         // relying party checks it for.
-        self.mint(&client, &spent.user_name, &spent.scopes, None)
+        self.mint(&client, &spent.user_name, &spent.scopes, None, spent.event)
             .await
     }
 
@@ -435,7 +450,7 @@ impl<S: OidcStore> OAuthService<S> {
 
         let claims = self
             .keys
-            .verify_claims::<OAuthClaims>(access_token, audience)
+            .verify_claims_as::<OAuthClaims>(access_token, audience, TokenType::AccessToken)
             .map_err(|_| refused())?;
 
         let scopes: Vec<String> = claims
@@ -503,6 +518,7 @@ impl<S: OidcStore> OAuthService<S> {
         user_name: &str,
         scopes: &[String],
         nonce: Option<String>,
+        event: Option<AuthenticationEvent>,
     ) -> Result<OidcTokens> {
         let now = Utc::now();
         let signing_failed = |e: crate::wami::sts::jwt::JwtError| {
@@ -511,7 +527,10 @@ impl<S: OidcStore> OAuthService<S> {
 
         let claims =
             builder::build_user_claims(client, user_name, scopes, &self.issuer, now, self.lifetime);
-        let access_token = self.keys.sign_claims(&claims).map_err(signing_failed)?;
+        let access_token = self
+            .keys
+            .sign_claims_as(&claims, self.access_token_type())
+            .map_err(signing_failed)?;
 
         let id_token = if scopes.iter().any(|s| s == "openid") {
             let profile = self.profile_of(user_name).await?;
@@ -523,6 +542,7 @@ impl<S: OidcStore> OAuthService<S> {
                     scopes,
                     profile: &profile,
                     nonce,
+                    event: event.as_ref(),
                 },
                 now,
                 self.lifetime,
@@ -540,6 +560,7 @@ impl<S: OidcStore> OAuthService<S> {
             expires_at: now + REFRESH_TOKEN_LIFETIME,
             used_at: None,
             replaced_by: None,
+            event,
         };
         let refresh_token = refresh.token.clone();
 
@@ -646,6 +667,7 @@ mod tests {
             scopes: scopes.iter().map(|s| s.to_string()).collect(),
             challenge: CodeChallenge::s256(derive_s256_challenge(VERIFIER)),
             nonce: Some("n-0S6".into()),
+            event: None,
             state: Some("xyz".into()),
         }
     }
@@ -898,6 +920,7 @@ mod tests {
             redirect_uri: REDIRECT.into(),
             challenge: Some(CodeChallenge::s256(derive_s256_challenge(VERIFIER))),
             nonce: None,
+            event: None,
             expires_at: Utc::now() - chrono::Duration::seconds(1),
         };
         service
@@ -1204,6 +1227,7 @@ mod tests {
             expires_at: Utc::now() - chrono::Duration::seconds(1),
             used_at: None,
             replaced_by: None,
+            event: None,
         };
         service
             .store
@@ -1229,6 +1253,193 @@ mod tests {
                 .await
                 .is_ok(),
             "the user's live token should have survived"
+        );
+    }
+
+    /// A sign-in the host reports: two hours ago, password plus a hardware key.
+    fn an_event() -> AuthenticationEvent {
+        AuthenticationEvent {
+            at: Utc::now() - chrono::Duration::hours(2),
+            acr: Some("urn:mace:incommon:iap:silver".into()),
+            amr: vec!["pwd".into(), "hwk".into()],
+        }
+    }
+
+    #[tokio::test]
+    async fn the_id_token_reports_the_sign_in_the_host_described() {
+        let service = service().await;
+        let event = an_event();
+        service
+            .grant_consent("app", "alice", vec!["openid".into()])
+            .await
+            .unwrap();
+        let mut req = request(&["openid"]);
+        req.event = Some(event.clone());
+        let code = match service.authorize(req).await.unwrap() {
+            Authorization::Code { code, .. } => code,
+            other => panic!("expected a code, got {other:?}"),
+        };
+
+        let tokens = service
+            .exchange_code(exchange(&code, VERIFIER))
+            .await
+            .unwrap();
+        let id: IdTokenClaims = service
+            .keys
+            .verify_claims(tokens.id_token.as_ref().unwrap(), "app")
+            .unwrap();
+
+        assert_eq!(id.auth_time, Some(event.at.timestamp()));
+        assert_eq!(id.acr, event.acr);
+        assert_eq!(id.amr, vec!["pwd", "hwk"]);
+    }
+
+    #[tokio::test]
+    async fn a_refreshed_id_token_reports_the_original_sign_in_not_the_refresh() {
+        // OIDC Core §12.2: auth_time "MUST represent the time of the original
+        // authentication - not the time that the new ID token is issued". A
+        // chain that recomputed it would silently reset the session age on
+        // every refresh, defeating a relying party that enforces max_age.
+        let service = service().await;
+        let event = an_event();
+        service
+            .grant_consent("app", "alice", vec!["openid".into()])
+            .await
+            .unwrap();
+        let mut req = request(&["openid"]);
+        req.event = Some(event.clone());
+        let code = match service.authorize(req).await.unwrap() {
+            Authorization::Code { code, .. } => code,
+            other => panic!("expected a code, got {other:?}"),
+        };
+        let first = service
+            .exchange_code(exchange(&code, VERIFIER))
+            .await
+            .unwrap();
+
+        let second = service
+            .refresh_tokens("app", "s3cret", &first.refresh_token)
+            .await
+            .unwrap();
+        let third = service
+            .refresh_tokens("app", "s3cret", &second.refresh_token)
+            .await
+            .unwrap();
+
+        for (which, tokens) in [("second", &second), ("third", &third)] {
+            let id: IdTokenClaims = service
+                .keys
+                .verify_claims(tokens.id_token.as_ref().unwrap(), "app")
+                .unwrap();
+            assert_eq!(
+                id.auth_time,
+                Some(event.at.timestamp()),
+                "{which} refresh moved auth_time"
+            );
+            assert_eq!(id.amr, vec!["pwd", "hwk"], "{which} refresh lost amr");
+            assert_eq!(id.nonce, None, "{which} refresh must not echo the nonce");
+        }
+    }
+
+    #[tokio::test]
+    async fn a_host_that_says_nothing_gets_no_authentication_claims() {
+        let service = service().await;
+        let code = a_code(&service, &["openid"]).await;
+        let tokens = service
+            .exchange_code(exchange(&code, VERIFIER))
+            .await
+            .unwrap();
+
+        let id: IdTokenClaims = service
+            .keys
+            .verify_claims(tokens.id_token.as_ref().unwrap(), "app")
+            .unwrap();
+        assert_eq!(id.auth_time, None);
+        assert_eq!(id.acr, None);
+        assert!(id.amr.is_empty());
+
+        // And they are absent from the wire, not present as nulls.
+        let json = serde_json::to_value(&id).unwrap();
+        for absent in ["auth_time", "acr", "amr"] {
+            assert!(json.get(absent).is_none(), "{absent} was serialised");
+        }
+    }
+
+    #[tokio::test]
+    async fn explicit_typing_labels_access_tokens_and_leaves_id_tokens_alone() {
+        let service = service().await.with_explicit_typ();
+        let code = a_code(&service, &["openid"]).await;
+        let tokens = service
+            .exchange_code(exchange(&code, VERIFIER))
+            .await
+            .unwrap();
+
+        let access = jsonwebtoken::decode_header(&tokens.access_token).unwrap();
+        assert_eq!(access.typ.as_deref(), Some("at+jwt"));
+
+        // OIDC registers no typ for ID tokens, so they keep JWT — and that
+        // difference is what makes the two impossible to confuse.
+        let id = jsonwebtoken::decode_header(tokens.id_token.as_ref().unwrap()).unwrap();
+        assert_eq!(id.typ.as_deref(), Some("JWT"));
+
+        assert!(
+            service
+                .keys
+                .verify_claims::<IdTokenClaims>(&tokens.access_token, "app")
+                .is_err(),
+            "a labelled access token must not pass as an ID token"
+        );
+    }
+
+    #[tokio::test]
+    async fn turning_typing_on_does_not_invalidate_tokens_already_issued() {
+        // The reason the switch is safe to flip in production: an access token
+        // signed before the flip carries `typ: JWT`, and introspection and
+        // /userinfo still accept it.
+        let untyped = service().await;
+        let code = a_code(&untyped, &["openid"]).await;
+        let tokens = untyped
+            .exchange_code(exchange(&code, VERIFIER))
+            .await
+            .unwrap();
+
+        let typed = OAuthService::new(
+            untyped.store.clone(),
+            untyped.keys.clone(),
+            "https://id.test".to_string(),
+        )
+        .with_user_claims(Arc::new(Directory))
+        .with_explicit_typ();
+
+        assert!(typed.user_info(&tokens.access_token, AUD).await.is_ok());
+        assert!(
+            typed
+                .introspect_token(&tokens.access_token, AUD)
+                .await
+                .unwrap()
+                .active
+        );
+    }
+
+    #[tokio::test]
+    async fn an_id_token_is_never_accepted_as_a_bearer_token() {
+        let service = service().await.with_explicit_typ();
+        let code = a_code(&service, &["openid"]).await;
+        let tokens = service
+            .exchange_code(exchange(&code, VERIFIER))
+            .await
+            .unwrap();
+        let id_token = tokens.id_token.unwrap();
+
+        // Two independent reasons it fails: the audience is the client, and
+        // once typing is on the label is wrong too.
+        assert!(service.user_info(&id_token, AUD).await.is_err());
+        assert!(
+            !service
+                .introspect_token(&id_token, AUD)
+                .await
+                .unwrap()
+                .active
         );
     }
 

--- a/crates/wami/src/store/memory/oauth/mod.rs
+++ b/crates/wami/src/store/memory/oauth/mod.rs
@@ -313,6 +313,7 @@ mod tests {
             redirect_uri: "https://app.test/cb".to_string(),
             challenge: None,
             nonce: None,
+            event: None,
             expires_at: Utc::now() + chrono::Duration::seconds(60),
         }
     }
@@ -326,6 +327,7 @@ mod tests {
             expires_at: Utc::now() + chrono::Duration::days(30),
             used_at: None,
             replaced_by: None,
+            event: None,
         }
     }
 

--- a/crates/wami/src/wami/oauth/builder.rs
+++ b/crates/wami/src/wami/oauth/builder.rs
@@ -44,6 +44,19 @@ pub fn build_client(
             message: "a client with no grant types can never obtain a token".to_string(),
         });
     }
+    // An access token is addressed to `audience`, an ID token to `client_id`.
+    // Letting them be the same string collapses the only thing that tells the
+    // two apart for a verifier that has not opted into RFC 9068 typing: an
+    // access token would then deserialise and verify as an ID token, which is
+    // exactly the confusion the audience split exists to prevent.
+    if audience == client_id {
+        return Err(AmiError::InvalidParameter {
+            message: format!(
+                "client {client_id} cannot use its own id as its audience: an access token \
+                 and an ID token would then be addressed identically"
+            ),
+        });
+    }
 
     Ok(OAuthClient {
         client_id,
@@ -189,6 +202,36 @@ mod tests {
             )
             .is_err());
         }
+    }
+
+    #[test]
+    fn a_client_cannot_take_its_own_id_as_its_audience() {
+        // Then an access token (aud = the audience) and an ID token (aud = the
+        // client id) would be addressed identically, and the audience — the
+        // only barrier before RFC 9068 typing — would stop separating them.
+        let err = build_client(
+            "gallery".into(),
+            "s",
+            "Gallery".into(),
+            vec![GrantType::AuthorizationCode],
+            vec!["openid".into()],
+            "gallery".into(),
+            vec![],
+        )
+        .unwrap_err();
+        assert!(matches!(err, AmiError::InvalidParameter { .. }));
+
+        // A different audience is fine.
+        assert!(build_client(
+            "gallery".into(),
+            "s",
+            "Gallery".into(),
+            vec![GrantType::AuthorizationCode],
+            vec!["openid".into()],
+            "photos-api".into(),
+            vec![],
+        )
+        .is_ok());
     }
 
     #[test]

--- a/crates/wami/src/wami/oauth/mod.rs
+++ b/crates/wami/src/wami/oauth/mod.rs
@@ -29,7 +29,8 @@ pub use model::{
 };
 pub use oidc::{
     build_discovery_document, build_id_token_claims, build_user_info, derive_s256_challenge,
-    generate_opaque_value, validate_redirect_uri, AuthorizationCode, CodeChallenge,
-    CodeChallengeMethod, DiscoveryDocument, IdTokenClaims, IdTokenRequest, RefreshToken,
-    UserConsent, UserInfo, UserProfile, AUTHORIZATION_CODE_LIFETIME, REFRESH_TOKEN_LIFETIME,
+    generate_opaque_value, validate_redirect_uri, AuthenticationEvent, AuthorizationCode,
+    CodeChallenge, CodeChallengeMethod, DiscoveryDocument, IdTokenClaims, IdTokenRequest,
+    RefreshToken, UserConsent, UserInfo, UserProfile, AUTHORIZATION_CODE_LIFETIME,
+    REFRESH_TOKEN_LIFETIME,
 };

--- a/crates/wami/src/wami/oauth/oidc.rs
+++ b/crates/wami/src/wami/oauth/oidc.rs
@@ -176,6 +176,20 @@ impl UserConsent {
 /// (`auth_time`) or care whether a password or a passkey was used
 /// (`acr`/`amr`). Without it they cannot tell, and some will refuse to
 /// federate.
+///
+/// # It describes one sign-in, for the life of one chain
+///
+/// The event is fixed when the authorization code is issued and carried
+/// unchanged through every refresh — `auth_time` must be, per OIDC Core §12.2,
+/// and `acr`/`amr` follow it because they describe the same moment.
+///
+/// So a user who signs in with a password and later adds a hardware key keeps
+/// reporting `amr: ["pwd"]` until the chain ends. That is not a gap to patch
+/// with a way to amend the event in place: a stronger authentication is a new
+/// authentication, and the honest way to reflect it is a new authorization —
+/// which mints a new chain with a new event. A relying party that needs a
+/// *fresh* assurance about how someone authenticated must ask for one, not
+/// trust a claim minted a month ago.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct AuthenticationEvent {
     /// When the user actually authenticated.

--- a/crates/wami/src/wami/oauth/oidc.rs
+++ b/crates/wami/src/wami/oauth/oidc.rs
@@ -87,6 +87,9 @@ pub struct AuthorizationCode {
     pub challenge: Option<CodeChallenge>,
     /// The client's nonce, carried into the ID token.
     pub nonce: Option<String>,
+    /// What the host reported about the sign-in, if anything.
+    #[serde(default)]
+    pub event: Option<AuthenticationEvent>,
     /// When it stops being redeemable.
     pub expires_at: DateTime<Utc>,
 }
@@ -122,6 +125,15 @@ pub struct RefreshToken {
     /// The token issued in its place, if any. Lets a reuse be traced to the
     /// chain it came from.
     pub replaced_by: Option<String>,
+    /// The sign-in this chain descends from.
+    ///
+    /// Carried rather than recomputed: OIDC Core §12.2 requires a refreshed ID
+    /// token's `auth_time` to be the *original* authentication time. A chain
+    /// that forgot it would silently reset the user's session age on every
+    /// refresh, which is exactly what a relying party enforcing `max_age` is
+    /// trying to detect.
+    #[serde(default)]
+    pub event: Option<AuthenticationEvent>,
 }
 
 impl RefreshToken {
@@ -154,6 +166,35 @@ impl UserConsent {
     }
 }
 
+/// How and when the host authenticated the user.
+///
+/// wami does not perform authentication, so it cannot know any of this — the
+/// host proves who is at the keyboard and reports what it did. Supplying it is
+/// optional; the claims it produces simply do not appear otherwise.
+///
+/// It matters to relying parties that enforce a maximum session age
+/// (`auth_time`) or care whether a password or a passkey was used
+/// (`acr`/`amr`). Without it they cannot tell, and some will refuse to
+/// federate.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct AuthenticationEvent {
+    /// When the user actually authenticated.
+    ///
+    /// The time of the *sign-in*, not of the token. OIDC Core §12.2 is explicit
+    /// that a refreshed ID token's `auth_time` "MUST represent the time of the
+    /// original authentication - not the time that the new ID token is issued",
+    /// which is why this travels with the refresh token rather than being
+    /// recomputed.
+    pub at: DateTime<Utc>,
+    /// Authentication Context Class Reference — how strong the sign-in was.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acr: Option<String>,
+    /// Authentication Methods References — what was used, e.g. `pwd`, `otp`,
+    /// `hwk`. Registered values are in RFC 8176.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub amr: Vec<String>,
+}
+
 /// The claims of an OpenID Connect ID token.
 ///
 /// An ID token says *who signed in*; an access token says *what may be done*.
@@ -184,9 +225,21 @@ pub struct IdTokenClaims {
     /// Present when the `email` scope was granted.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub email: Option<String>,
+    /// When the user authenticated, as a Unix timestamp.
+    ///
+    /// Present only when the host reported an [`AuthenticationEvent`], and it
+    /// is the time of the original sign-in even on a refreshed token.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auth_time: Option<i64>,
+    /// How strong the sign-in was.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub acr: Option<String>,
+    /// What the user authenticated with.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub amr: Vec<String>,
 }
 
-// Two claims a reviewer will look for here and not find.
+// One claim a reviewer will look for here and not find.
 //
 // `at_hash` is OPTIONAL for an ID token returned from the token endpoint in the
 // authorization code flow (OIDC Core §3.1.3.6 — it is only REQUIRED where a
@@ -196,10 +249,6 @@ pub struct IdTokenClaims {
 // internal SHA-512. An `at_hash` a relying party computes differently is a hard
 // validation failure, where its absence is a no-op. Absent is the safer answer
 // until EdDSA has a settled convention.
-//
-// `auth_time`, `acr` and `amr` describe the authentication event, and wami does
-// not perform it — the host does, before it ever calls `authorize`. Supporting
-// them means the host passing the event in, which is additive and not yet done.
 
 /// The profile claims wami puts in an ID token when the scopes allow it.
 ///
@@ -296,6 +345,8 @@ pub struct IdTokenRequest<'a> {
     pub profile: &'a UserProfile,
     /// The client's nonce, echoed back.
     pub nonce: Option<String>,
+    /// What the host reported about the sign-in.
+    pub event: Option<&'a AuthenticationEvent>,
 }
 
 /// Build the claims of an ID token.
@@ -318,6 +369,9 @@ pub fn build_id_token_claims(
         nonce: request.nonce,
         name: name.cloned(),
         email: email.cloned(),
+        auth_time: request.event.map(|e| e.at.timestamp()),
+        acr: request.event.and_then(|e| e.acr.clone()),
+        amr: request.event.map(|e| e.amr.clone()).unwrap_or_default(),
     }
 }
 
@@ -419,6 +473,7 @@ mod tests {
             expires_at: now + Duration::days(30),
             used_at: None,
             replaced_by: None,
+            event: None,
         };
         assert!(token.is_usable_at(now));
 
@@ -440,6 +495,7 @@ mod tests {
             expires_at: now - Duration::seconds(1),
             used_at: None,
             replaced_by: None,
+            event: None,
         };
         assert!(!token.is_usable_at(now));
     }
@@ -515,6 +571,7 @@ mod tests {
                 scopes: &scopes,
                 profile: &a_profile(),
                 nonce: None,
+                event: None,
             },
             Utc::now(),
             Duration::minutes(5),
@@ -549,6 +606,7 @@ mod tests {
                 scopes: &scopes,
                 profile: &profile,
                 nonce: None,
+                event: None,
             },
             Utc::now(),
             Duration::minutes(5),
@@ -571,6 +629,7 @@ mod tests {
                 scopes: &["openid".to_string()],
                 profile: &UserProfile::default(),
                 nonce: Some("n-0S6_WzA2Mj".into()),
+                event: None,
             },
             now,
             Duration::minutes(5),

--- a/crates/wami/src/wami/sts/jwt.rs
+++ b/crates/wami/src/wami/sts/jwt.rs
@@ -44,6 +44,60 @@ pub struct Jwk {
     pub x: String,
 }
 
+/// What a signed token declares itself to be, in the JOSE `typ` header.
+///
+/// # Why this exists
+///
+/// wami signs access tokens and ID tokens with one keyset. They are told apart
+/// by `aud` — an access token names the resource server, an ID token names the
+/// client — and that holds, as long as the verifier checks the audience.
+/// RFC 9068 adds a structural label so it does not have to:
+///
+/// > The explicit typing required in this profile [...] helps the resource
+/// > server to distinguish between JWT access tokens and OpenID Connect ID
+/// > Tokens.
+///
+/// # Why it is not the default
+///
+/// Every token wami has issued so far carries `typ: JWT`. Switching that to
+/// `at+jwt` unannounced would break a resource server that pins the old value.
+/// Issuance is opt-in — see
+/// [`OAuthService::with_explicit_typ`][crate::service::oauth::OAuthService::with_explicit_typ]
+/// — and verification stays lenient about which of the two it sees, so turning
+/// it on does not invalidate the tokens already in flight.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum TokenType {
+    /// `JWT` — the unlabelled default. What every token carried before RFC 9068
+    /// typing was an option, and what ID tokens still carry: OIDC registers no
+    /// `typ` of its own for them.
+    Jwt,
+    /// `at+jwt` — an OAuth 2.0 access token, RFC 9068.
+    AccessToken,
+}
+
+impl TokenType {
+    /// The header value.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            TokenType::Jwt => "JWT",
+            TokenType::AccessToken => "at+jwt",
+        }
+    }
+
+    /// Parse a `typ` header value.
+    ///
+    /// RFC 9068 §4: a resource server accepts `at+jwt` or `application/at+jwt`.
+    /// The media-type prefix is optional in JOSE headers and both forms are on
+    /// the wire, so both are read.
+    pub fn parse(typ: &str) -> Option<Self> {
+        match typ {
+            "JWT" | "jwt" => Some(TokenType::Jwt),
+            "at+jwt" | "application/at+jwt" => Some(TokenType::AccessToken),
+            _ => None,
+        }
+    }
+}
+
 /// Structured claims embedded in a signed JWT for STS credentials.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct StsClaims {
@@ -245,8 +299,20 @@ impl KeyManager {
     /// with the same keys and the same rotation, instead of each growing its own
     /// signer. Existing callers infer `StsClaims` from the argument.
     pub fn sign_claims<C: Serialize>(&self, claims: &C) -> Result<String, JwtError> {
+        self.sign_claims_as(claims, TokenType::Jwt)
+    }
+
+    /// Sign claims, declaring in the header what kind of token this is.
+    ///
+    /// See [`TokenType`] for what the label buys and why it is not the default.
+    pub fn sign_claims_as<C: Serialize>(
+        &self,
+        claims: &C,
+        typ: TokenType,
+    ) -> Result<String, JwtError> {
         let mut header = Header::new(Algorithm::EdDSA);
         header.kid = Some(self.active.kid.clone());
+        header.typ = Some(typ.as_str().to_string());
         let pkcs8_der = self
             .active
             .signing_key
@@ -275,6 +341,67 @@ impl KeyManager {
     /// share every check, so key rotation and audience validation cannot drift
     /// apart between issuers.
     pub fn verify_claims<C: DeserializeOwned>(
+        &self,
+        token: &str,
+        audience: &str,
+    ) -> Result<C, JwtError> {
+        self.verify_claims_as(token, audience, TokenType::Jwt)
+    }
+
+    /// Verify a token that must be of a given kind, and deserialise it.
+    ///
+    /// # What the `typ` header is allowed to say
+    ///
+    /// A token may be labelled less specifically than expected, never
+    /// differently. Concretely:
+    ///
+    /// | expecting | header says | |
+    /// |---|---|---|
+    /// | [`TokenType::AccessToken`] | absent, `JWT`, or `at+jwt` | accepted |
+    /// | [`TokenType::Jwt`] | absent or `JWT` | accepted |
+    /// | [`TokenType::Jwt`] | `at+jwt` | **refused** |
+    /// | either | anything else | refused |
+    ///
+    /// The asymmetry is the whole point, and it is what makes explicit typing
+    /// safe to turn on mid-flight. An access token is accepted with the old
+    /// unlabelled header, so enabling
+    /// [`with_explicit_typ`][crate::service::oauth::OAuthService::with_explicit_typ]
+    /// does not invalidate the tokens already issued. But once a token *is*
+    /// labelled `at+jwt`, nothing will read it as an ID token — which is the
+    /// confusion RFC 9068 exists to end.
+    ///
+    /// # Errors
+    ///
+    /// [`JwtError::TokenTypeMismatch`] when the label is wrong, before the
+    /// signature is examined. A forged label is caught anyway: `typ` is inside
+    /// the signed JOSE header, so changing it breaks the signature.
+    pub fn verify_claims_as<C: DeserializeOwned>(
+        &self,
+        token: &str,
+        audience: &str,
+        expected: TokenType,
+    ) -> Result<C, JwtError> {
+        if let Some(declared) = jsonwebtoken::decode_header(token)
+            .map_err(JwtError::Decode)?
+            .typ
+        {
+            let acceptable = match TokenType::parse(&declared) {
+                Some(TokenType::Jwt) => true,
+                Some(TokenType::AccessToken) => expected == TokenType::AccessToken,
+                None => false,
+            };
+            if !acceptable {
+                return Err(JwtError::TokenTypeMismatch {
+                    expected: expected.as_str(),
+                    found: declared,
+                });
+            }
+        }
+        self.verify_signed_claims(token, audience)
+    }
+
+    /// Everything after the `typ` check: key lookup, signature, audience.
+    fn verify_signed_claims<C: DeserializeOwned>(
         &self,
         token: &str,
         audience: &str,
@@ -398,6 +525,16 @@ pub enum JwtError {
         /// The audience the verifier was asked to accept.
         expected: String,
     },
+    /// The token declares a `typ` that cannot be what the verifier asked for.
+    /// The case that matters: an RFC 9068 access token presented where an ID
+    /// token belongs.
+    #[error("token declares typ `{found}`, which cannot serve as `{expected}`")]
+    TokenTypeMismatch {
+        /// What the verifier wanted.
+        expected: &'static str,
+        /// What the header said.
+        found: String,
+    },
 }
 
 #[cfg(test)]
@@ -484,6 +621,95 @@ mod tests {
         assert_eq!(verified.jti, claims.jti);
         assert_eq!(verified.scoped_actions, claims.scoped_actions);
         assert_eq!(verified.scoped_resources, claims.scoped_resources);
+    }
+
+    #[test]
+    fn an_unlabelled_token_still_verifies_as_either_kind() {
+        // The whole reason typing is opt-in: nothing already in flight breaks.
+        let km = KeyManager::generate();
+        let claims = build_sts_claims(&test_credentials(), &test_claims_context());
+        let token = km.sign_claims(&claims).unwrap();
+
+        assert!(km
+            .verify_claims_as::<StsClaims>(&token, AUD, TokenType::Jwt)
+            .is_ok());
+        assert!(km
+            .verify_claims_as::<StsClaims>(&token, AUD, TokenType::AccessToken)
+            .is_ok());
+    }
+
+    #[test]
+    fn an_access_token_cannot_be_read_as_an_id_token() {
+        // The protection RFC 9068 exists to give. Once a token says `at+jwt`,
+        // no verifier expecting an ID token will take it.
+        let km = KeyManager::generate();
+        let claims = build_sts_claims(&test_credentials(), &test_claims_context());
+        let token = km.sign_claims_as(&claims, TokenType::AccessToken).unwrap();
+
+        assert!(km
+            .verify_claims_as::<StsClaims>(&token, AUD, TokenType::AccessToken)
+            .is_ok());
+
+        let err = km
+            .verify_claims_as::<StsClaims>(&token, AUD, TokenType::Jwt)
+            .unwrap_err();
+        match err {
+            JwtError::TokenTypeMismatch { found, expected } => {
+                assert_eq!(found, "at+jwt");
+                assert_eq!(expected, "JWT");
+            }
+            other => panic!("got {other:?}"),
+        }
+
+        // `verify_claims` is the ID-token-shaped door, so it refuses too.
+        assert!(km.verify_claims::<StsClaims>(&token, AUD).is_err());
+    }
+
+    #[test]
+    fn the_typ_header_says_what_was_asked_for() {
+        let km = KeyManager::generate();
+        let claims = build_sts_claims(&test_credentials(), &test_claims_context());
+
+        for (typ, expected) in [(TokenType::Jwt, "JWT"), (TokenType::AccessToken, "at+jwt")] {
+            let token = km.sign_claims_as(&claims, typ).unwrap();
+            let header = jsonwebtoken::decode_header(&token).unwrap();
+            assert_eq!(header.typ.as_deref(), Some(expected));
+            assert!(header.kid.is_some(), "rotation still needs the kid");
+        }
+    }
+
+    #[test]
+    fn both_spellings_of_the_access_token_type_are_read() {
+        // RFC 9068 §4 allows the media-type prefix; both are on the wire.
+        assert_eq!(TokenType::parse("at+jwt"), Some(TokenType::AccessToken));
+        assert_eq!(
+            TokenType::parse("application/at+jwt"),
+            Some(TokenType::AccessToken)
+        );
+        assert_eq!(TokenType::parse("JWT"), Some(TokenType::Jwt));
+        assert_eq!(TokenType::parse("dpop+jwt"), None);
+    }
+
+    #[test]
+    fn a_typ_nobody_recognises_is_refused_for_either_kind() {
+        let km = KeyManager::generate();
+        let claims = build_sts_claims(&test_credentials(), &test_claims_context());
+        let mut header = Header::new(Algorithm::EdDSA);
+        header.kid = Some(km.active.kid.clone());
+        header.typ = Some("dpop+jwt".to_string());
+        let pkcs8 = km.active.signing_key.to_pkcs8_der().unwrap();
+        let token = encode(
+            &header,
+            &claims,
+            &EncodingKey::from_ed_der(pkcs8.as_bytes()),
+        )
+        .unwrap();
+
+        for expected in [TokenType::Jwt, TokenType::AccessToken] {
+            assert!(km
+                .verify_claims_as::<StsClaims>(&token, AUD, expected)
+                .is_err());
+        }
     }
 
     #[test]

--- a/crates/wami/src/wami/sts/jwt.rs
+++ b/crates/wami/src/wami/sts/jwt.rs
@@ -63,8 +63,8 @@ pub struct Jwk {
 /// `at+jwt` unannounced would break a resource server that pins the old value.
 /// Issuance is opt-in — see
 /// [`OAuthService::with_explicit_typ`][crate::service::oauth::OAuthService::with_explicit_typ]
-/// — and verification stays lenient about which of the two it sees, so turning
-/// it on does not invalidate the tokens already in flight.
+/// — and [`KeyManager::verify_claims`] never looks at the label at all, so a
+/// verifier written before any of this existed keeps working unchanged.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum TokenType {
     /// `JWT` — the unlabelled default. What every token carried before RFC 9068
@@ -96,6 +96,20 @@ impl TokenType {
             _ => None,
         }
     }
+}
+
+/// How strictly a verifier holds a token to its declared [`TokenType`].
+///
+/// The distinction exists because RFC 9068 conformance and a live migration
+/// want opposite things, and only the deployment knows which it is in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TypePolicy {
+    /// An unlabelled token, or one labelled `JWT`, passes anywhere. Only a
+    /// label that is *more* specific and *wrong* is refused.
+    Lenient,
+    /// The label must be exactly what was asked for. An unlabelled token is
+    /// refused. This is RFC 9068 §4 as written.
+    Strict,
 }
 
 /// Structured claims embedded in a signed JWT for STS credentials.
@@ -340,64 +354,101 @@ impl KeyManager {
     /// [`KeyManager::verify_token`] is this with `StsClaims` filled in; the two
     /// share every check, so key rotation and audience validation cannot drift
     /// apart between issuers.
+    ///
+    /// The `typ` header is **not** examined. This is the historical door and
+    /// its contract predates RFC 9068 typing: a verifier that has been calling
+    /// it since before [`TokenType`] existed must not start failing because
+    /// some issuer, elsewhere, turned labelling on. Callers who want the label
+    /// enforced ask for it — see [`verify_claims_as`].
+    ///
+    /// [`verify_claims_as`]: Self::verify_claims_as
     pub fn verify_claims<C: DeserializeOwned>(
         &self,
         token: &str,
         audience: &str,
     ) -> Result<C, JwtError> {
-        self.verify_claims_as(token, audience, TokenType::Jwt)
+        self.verify_signed_claims(token, audience)
     }
 
     /// Verify a token that must be of a given kind, and deserialise it.
     ///
-    /// # What the `typ` header is allowed to say
+    /// The signature and the audience are checked first, always. The label is
+    /// examined only once the token has proven genuine, so no decision here
+    /// rests on bytes an attacker chose.
     ///
-    /// A token may be labelled less specifically than expected, never
-    /// differently. Concretely:
+    /// # Which labels pass
     ///
-    /// | expecting | header says | |
-    /// |---|---|---|
-    /// | [`TokenType::AccessToken`] | absent, `JWT`, or `at+jwt` | accepted |
-    /// | [`TokenType::Jwt`] | absent or `JWT` | accepted |
-    /// | [`TokenType::Jwt`] | `at+jwt` | **refused** |
-    /// | either | anything else | refused |
+    /// | policy | expecting | header says | |
+    /// |---|---|---|---|
+    /// | [`Lenient`] | [`AccessToken`] | absent, `JWT`, or `at+jwt` | accepted |
+    /// | [`Lenient`] | [`Jwt`] | absent or `JWT` | accepted |
+    /// | [`Lenient`] | [`Jwt`] | `at+jwt` | refused |
+    /// | [`Strict`] | either | exactly the expected label | accepted |
+    /// | either | either | anything unrecognised | refused |
     ///
-    /// The asymmetry is the whole point, and it is what makes explicit typing
-    /// safe to turn on mid-flight. An access token is accepted with the old
-    /// unlabelled header, so enabling
-    /// [`with_explicit_typ`][crate::service::oauth::OAuthService::with_explicit_typ]
-    /// does not invalidate the tokens already issued. But once a token *is*
-    /// labelled `at+jwt`, nothing will read it as an ID token — which is the
-    /// confusion RFC 9068 exists to end.
+    /// # Choosing a policy
+    ///
+    /// [`Lenient`] is for a deployment mid-migration: a token issued before
+    /// labelling was enabled carries no useful `typ`, and refusing it would
+    /// mean an outage every time an issuer flips
+    /// [`with_explicit_typ`][crate::service::oauth::OAuthService::with_explicit_typ].
+    /// It still closes the direction that matters — a token labelled `at+jwt`
+    /// will not pass as an ID token.
+    ///
+    /// [`Strict`] is what RFC 9068 §4 actually asks of a resource server:
+    ///
+    /// > The resource server MUST verify that the `typ` header value is
+    /// > `at+jwt` or `application/at+jwt` and reject tokens carrying any other
+    /// > value.
+    ///
+    /// Reach for it once every issuer you accept is labelling. Until then it
+    /// refuses your own legacy tokens, which is the point of it being a
+    /// choice rather than a default.
     ///
     /// # Errors
     ///
-    /// [`JwtError::TokenTypeMismatch`] when the label is wrong, before the
-    /// signature is examined. A forged label is caught anyway: `typ` is inside
-    /// the signed JOSE header, so changing it breaks the signature.
+    /// [`JwtError::TokenTypeMismatch`] when the token is genuine but labelled
+    /// something this call cannot accept.
+    ///
+    /// [`Lenient`]: TypePolicy::Lenient
+    /// [`Strict`]: TypePolicy::Strict
+    /// [`AccessToken`]: TokenType::AccessToken
+    /// [`Jwt`]: TokenType::Jwt
     pub fn verify_claims_as<C: DeserializeOwned>(
         &self,
         token: &str,
         audience: &str,
         expected: TokenType,
+        policy: TypePolicy,
     ) -> Result<C, JwtError> {
-        if let Some(declared) = jsonwebtoken::decode_header(token)
+        // Signature and audience first. Everything below reads a header that
+        // has already been proven to be the one the issuer signed.
+        let claims = self.verify_signed_claims(token, audience)?;
+
+        let declared = jsonwebtoken::decode_header(token)
             .map_err(JwtError::Decode)?
-            .typ
-        {
-            let acceptable = match TokenType::parse(&declared) {
-                Some(TokenType::Jwt) => true,
-                Some(TokenType::AccessToken) => expected == TokenType::AccessToken,
-                None => false,
-            };
-            if !acceptable {
-                return Err(JwtError::TokenTypeMismatch {
-                    expected: expected.as_str(),
-                    found: declared,
-                });
-            }
+            .typ;
+
+        let acceptable = match (declared.as_deref().map(TokenType::parse), policy) {
+            // No label. Genuine, and says nothing about what it is.
+            (None, TypePolicy::Lenient) => true,
+            (None, TypePolicy::Strict) => false,
+            // A label nobody recognises — `dpop+jwt`, say. Never ours.
+            (Some(None), _) => false,
+            (Some(Some(found)), TypePolicy::Strict) => found == expected,
+            // Lenient: `JWT` is the unlabelled shape spelled out, so it passes
+            // wherever no label would. Anything more specific must match.
+            (Some(Some(TokenType::Jwt)), TypePolicy::Lenient) => true,
+            (Some(Some(found)), TypePolicy::Lenient) => found == expected,
+        };
+
+        if !acceptable {
+            return Err(JwtError::TokenTypeMismatch {
+                expected: expected.as_str(),
+                found: declared.unwrap_or_else(|| "<absent>".to_string()),
+            });
         }
-        self.verify_signed_claims(token, audience)
+        Ok(claims)
     }
 
     /// Everything after the `typ` check: key lookup, signature, audience.
@@ -624,45 +675,108 @@ mod tests {
     }
 
     #[test]
-    fn an_unlabelled_token_still_verifies_as_either_kind() {
-        // The whole reason typing is opt-in: nothing already in flight breaks.
+    fn the_historical_door_never_looks_at_the_label() {
+        // `verify_claims` predates typing. A verifier calling it must not start
+        // failing because some issuer, elsewhere, turned labelling on — it did
+        // not ask for the label and never agreed to be bound by it.
+        let km = KeyManager::generate();
+        let claims = build_sts_claims(&test_credentials(), &test_claims_context());
+
+        for typ in [TokenType::Jwt, TokenType::AccessToken] {
+            let token = km.sign_claims_as(&claims, typ).unwrap();
+            assert!(
+                km.verify_claims::<StsClaims>(&token, AUD).is_ok(),
+                "{typ:?} was refused by the untyped door"
+            );
+            assert!(km.verify_token(&token, AUD).is_ok());
+        }
+    }
+
+    #[test]
+    fn leniently_an_unlabelled_token_passes_as_either_kind() {
+        // The reason typing can be switched on mid-flight: tokens issued
+        // before it carry no useful label, and still verify.
         let km = KeyManager::generate();
         let claims = build_sts_claims(&test_credentials(), &test_claims_context());
         let token = km.sign_claims(&claims).unwrap();
 
-        assert!(km
-            .verify_claims_as::<StsClaims>(&token, AUD, TokenType::Jwt)
-            .is_ok());
-        assert!(km
-            .verify_claims_as::<StsClaims>(&token, AUD, TokenType::AccessToken)
-            .is_ok());
+        for expected in [TokenType::Jwt, TokenType::AccessToken] {
+            assert!(km
+                .verify_claims_as::<StsClaims>(&token, AUD, expected, TypePolicy::Lenient)
+                .is_ok());
+        }
     }
 
     #[test]
-    fn an_access_token_cannot_be_read_as_an_id_token() {
-        // The protection RFC 9068 exists to give. Once a token says `at+jwt`,
-        // no verifier expecting an ID token will take it.
+    fn leniently_an_access_token_still_cannot_be_read_as_an_id_token() {
+        // The one direction lenience does not forgive, and the confusion
+        // RFC 9068 exists to end.
         let km = KeyManager::generate();
         let claims = build_sts_claims(&test_credentials(), &test_claims_context());
         let token = km.sign_claims_as(&claims, TokenType::AccessToken).unwrap();
 
         assert!(km
-            .verify_claims_as::<StsClaims>(&token, AUD, TokenType::AccessToken)
+            .verify_claims_as::<StsClaims>(&token, AUD, TokenType::AccessToken, TypePolicy::Lenient)
             .is_ok());
 
-        let err = km
-            .verify_claims_as::<StsClaims>(&token, AUD, TokenType::Jwt)
-            .unwrap_err();
-        match err {
+        match km
+            .verify_claims_as::<StsClaims>(&token, AUD, TokenType::Jwt, TypePolicy::Lenient)
+            .unwrap_err()
+        {
             JwtError::TokenTypeMismatch { found, expected } => {
                 assert_eq!(found, "at+jwt");
                 assert_eq!(expected, "JWT");
             }
             other => panic!("got {other:?}"),
         }
+    }
 
-        // `verify_claims` is the ID-token-shaped door, so it refuses too.
-        assert!(km.verify_claims::<StsClaims>(&token, AUD).is_err());
+    #[test]
+    fn strictly_only_the_exact_label_passes() {
+        // RFC 9068 §4 as written: a resource server rejects anything that is
+        // not `at+jwt`, an unlabelled legacy token included. That is why it is
+        // a choice — turning it on before every issuer labels locks them out.
+        let km = KeyManager::generate();
+        let claims = build_sts_claims(&test_credentials(), &test_claims_context());
+
+        let labelled = km.sign_claims_as(&claims, TokenType::AccessToken).unwrap();
+        assert!(km
+            .verify_claims_as::<StsClaims>(
+                &labelled,
+                AUD,
+                TokenType::AccessToken,
+                TypePolicy::Strict
+            )
+            .is_ok());
+
+        let legacy = km.sign_claims(&claims).unwrap();
+        let err = km
+            .verify_claims_as::<StsClaims>(&legacy, AUD, TokenType::AccessToken, TypePolicy::Strict)
+            .unwrap_err();
+        assert!(
+            matches!(&err, JwtError::TokenTypeMismatch { found, .. } if found == "JWT"),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn a_bad_signature_is_reported_as_such_even_when_the_label_is_also_wrong() {
+        // The label is examined only after the token has proven genuine, so no
+        // answer here is decided by bytes an attacker chose.
+        let km = KeyManager::generate();
+        let other = KeyManager::generate();
+        let claims = build_sts_claims(&test_credentials(), &test_claims_context());
+        let foreign = other
+            .sign_claims_as(&claims, TokenType::AccessToken)
+            .unwrap();
+
+        let err = km
+            .verify_claims_as::<StsClaims>(&foreign, AUD, TokenType::Jwt, TypePolicy::Lenient)
+            .unwrap_err();
+        assert!(
+            !matches!(err, JwtError::TokenTypeMismatch { .. }),
+            "the label must not be judged before the signature: {err:?}"
+        );
     }
 
     #[test]
@@ -691,7 +805,7 @@ mod tests {
     }
 
     #[test]
-    fn a_typ_nobody_recognises_is_refused_for_either_kind() {
+    fn a_typ_nobody_recognises_is_refused_under_either_policy() {
         let km = KeyManager::generate();
         let claims = build_sts_claims(&test_credentials(), &test_claims_context());
         let mut header = Header::new(Algorithm::EdDSA);
@@ -706,10 +820,17 @@ mod tests {
         .unwrap();
 
         for expected in [TokenType::Jwt, TokenType::AccessToken] {
-            assert!(km
-                .verify_claims_as::<StsClaims>(&token, AUD, expected)
-                .is_err());
+            for policy in [TypePolicy::Lenient, TypePolicy::Strict] {
+                assert!(
+                    km.verify_claims_as::<StsClaims>(&token, AUD, expected, policy)
+                        .is_err(),
+                    "{expected:?}/{policy:?} accepted dpop+jwt"
+                );
+            }
         }
+
+        // But the untyped door does not care, by design.
+        assert!(km.verify_claims::<StsClaims>(&token, AUD).is_ok());
     }
 
     #[test]

--- a/docs/OAUTH_OIDC_GUIDE.md
+++ b/docs/OAUTH_OIDC_GUIDE.md
@@ -1,0 +1,461 @@
+# OAuth 2.0 & OpenID Connect Guide
+
+wami as an authorization server and an OpenID Provider. One Ed25519 keyset signs
+everything — STS credentials, machine-to-machine access tokens, and ID tokens —
+so there is one JWKS to publish and one rotation policy to run.
+
+## Table of Contents
+
+1. [What wami does, and what it does not](#what-wami-does-and-what-it-does-not)
+2. [Machine-to-machine: client credentials](#machine-to-machine-client-credentials)
+3. [Users: authorization code with PKCE](#users-authorization-code-with-pkce)
+4. [The flow, end to end](#the-flow-end-to-end)
+5. [Two tokens, two audiences](#two-tokens-two-audiences)
+6. [Explicit token typing (RFC 9068)](#explicit-token-typing-rfc-9068)
+7. [Reporting the sign-in](#reporting-the-sign-in)
+8. [Refresh rotation and leak detection](#refresh-rotation-and-leak-detection)
+9. [Implementing a store](#implementing-a-store)
+10. [What is deliberately absent](#what-is-deliberately-absent)
+
+---
+
+## What wami does, and what it does not
+
+**wami decides what may be issued, and signs it.**
+
+It does **not** authenticate the user, and it serves **no HTTP**. The host
+application proves who is at the keyboard — a password, a passkey, an upstream
+IdP — mounts the endpoints the discovery document advertises, and hands the
+browser its redirects.
+
+That split is why `authorize` takes a `user_name` rather than credentials: by
+the time wami is called, the question of *who* is already settled.
+
+> If you want the opposite direction — wami consuming an external IdP rather
+> than being one — see `IdentityProviderService`.
+
+---
+
+## Machine-to-machine: client credentials
+
+A service authenticates as itself and receives a short-lived signed JWT.
+
+```rust
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use wami::service::oauth::OAuthService;
+use wami::store::memory::InMemoryOAuthStore;
+use wami::wami::oauth::{build_client, generate_client_secret, GrantRequest, GrantType};
+use wami::wami::sts::jwt::KeyManager;
+
+let store = Arc::new(RwLock::new(InMemoryOAuthStore::new()));
+let keys = Arc::new(KeyManager::generate());
+let service = OAuthService::new(store, keys, "https://id.example.test".to_string());
+
+let secret = generate_client_secret();
+let client = build_client(
+    "nightly-reports".to_string(),
+    &secret,                                  // hashed on the way in
+    "Nightly reporting job".to_string(),
+    vec![GrantType::ClientCredentials],
+    vec!["reports:read".to_string()],
+    "reporting-api".to_string(),              // the audience
+    vec![],                                   // no redirect URIs needed
+)?;
+service.register_client(client).await?;
+
+let token = service.issue_token(GrantRequest::ClientCredentials {
+    client_id: "nightly-reports".to_string(),
+    client_secret: secret,
+    scope: vec!["reports:read".to_string()],
+}).await?;
+```
+
+Scopes are a ceiling, not a suggestion: asking for one the client does not hold
+is **refused**, not silently narrowed. A client that believes it holds a scope
+it does not is worse off than one told it cannot have it.
+
+Introspection (RFC 7662) and revocation (RFC 7009) work as specified, including
+the part where an inactive token discloses nothing but `active: false`.
+
+> **The limit worth knowing.** A signed token is verifiable offline, so a
+> verifier that checks the signature locally keeps accepting a revoked token
+> until it expires. Revocation binds on whoever *introspects*. That is why the
+> default lifetime is 15 minutes, and why anything with immediate cost should
+> introspect rather than verify locally.
+
+Runnable: [`examples/27_oauth_client_credentials.rs`](../crates/wami/examples/27_oauth_client_credentials.rs)
+
+---
+
+## Users: authorization code with PKCE
+
+The host authenticates the user, then asks wami for a code:
+
+```rust
+use wami::service::oauth::oidc::{Authorization, AuthorizationRequest, CodeExchange};
+use wami::wami::oauth::{derive_s256_challenge, CodeChallenge};
+
+// The client generated a verifier and kept it; only its hash travels.
+let challenge = CodeChallenge::s256(derive_s256_challenge(&verifier));
+
+let request = AuthorizationRequest {
+    client_id: "gallery".to_string(),
+    user_name: "alice".to_string(),          // the host just authenticated her
+    redirect_uri: "https://gallery.example.test/callback".to_string(),
+    scopes: vec!["openid".into(), "profile".into()],
+    challenge,                                // NOT an Option — see below
+    nonce: Some("n-0S6_WzA2Mj".to_string()),
+    event: None,                              // see "Reporting the sign-in"
+    state: Some("opaque-client-state".to_string()),
+};
+
+match service.authorize(request).await? {
+    Authorization::ConsentRequired { scopes, .. } => {
+        // Show a screen. Nothing was issued.
+        service.grant_consent("gallery", "alice", scopes).await?;
+        // Then call authorize again.
+    }
+    Authorization::Code { code, redirect_uri, state } => {
+        // 302 to redirect_uri?code=..&state=..
+    }
+}
+```
+
+Then the client redeems it:
+
+```rust
+let tokens = service.exchange_code(CodeExchange {
+    client_id: "gallery".to_string(),
+    client_secret: secret,
+    code,
+    redirect_uri: "https://gallery.example.test/callback".to_string(),
+    code_verifier: verifier,
+}).await?;
+// tokens.access_token, tokens.refresh_token, tokens.id_token
+```
+
+Runnable: [`examples/28_oidc_authorization_code.rs`](../crates/wami/examples/28_oidc_authorization_code.rs)
+
+### `state` is yours to check
+
+wami passes `state` through untouched and does nothing with it — it cannot.
+`state` defends against CSRF by being compared **at the callback**, and wami
+never sees the callback; it has no browser session to bind to.
+
+**The host must** generate it, tie it to the user agent's session, and reject a
+callback whose `state` does not match. Passing it through here saves you
+carrying it yourself; it is not a check.
+
+---
+
+## The flow, end to end
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor U as User
+    participant H as Host app
+    participant S as OAuthService
+    participant St as Store
+    participant K as KeyManager
+    participant C as Client
+    participant RS as Resource server
+
+    rect rgb(232,244,255)
+    Note over U,St: A. registration refuses a collapsed audience
+    H->>S: build_client(client_id, .., audience, ..)
+    alt audience == client_id
+        S-->>H: InvalidParameter
+        Note right of S: an access token (aud=audience) and an ID token<br/>(aud=client_id) would be addressed identically,<br/>and aud would stop separating them
+    end
+    end
+
+    rect rgb(240,248,255)
+    Note over U,St: B. the host may describe the sign-in
+    H->>U: password + hardware key
+    H->>S: authorize(.., event: Some(AuthenticationEvent{at, acr, amr}))
+    S->>St: store_authorization_code{ .., event }
+    end
+
+    rect rgb(255,248,235)
+    Note over S,K: C. mint
+    C->>S: exchange_code(code, verifier)
+    S->>St: consume_authorization_code (one op)
+    S->>K: sign_claims_as(access, access_token_type())
+    Note right of K: at+jwt with with_explicit_typ(), else JWT
+    opt openid granted
+        S->>K: sign_claims_as(id, TokenType::Jwt)
+        Note right of K: ID tokens always JWT — OIDC registers no typ
+    end
+    S->>St: store_refresh_token{ .., event }
+    S-->>C: OidcTokens
+    end
+
+    rect rgb(255,235,238)
+    Note over C,St: D. refresh — the old token is spent, not kept
+    C->>S: refresh_tokens(old)
+    S->>St: rotate_refresh_token(old, replacement{event: existing.event})
+    St->>St: old.used_at = now; old.replaced_by = replacement
+    St-->>S: the record it took
+    alt replaced_by != our replacement
+        alt used_at was None
+            S-->>C: AccessDenied — expired, chain untouched
+        else used_at was Some
+            S->>St: revoke_refresh_chain
+            S-->>C: AccessDenied — reuse, chain revoked
+        end
+    end
+    S->>K: sign id{ auth_time = event.at, nonce = None }
+    Note right of K: §12.2 — the ORIGINAL sign-in
+    end
+
+    rect rgb(240,255,240)
+    Note over C,RS: E. the three verification doors
+    RS->>K: verify_claims(token, aud)
+    Note right of K: no typ examined, ever.<br/>pre-RFC-9068 contract, unchanged
+    RS->>K: verify_claims_as(token, aud, AccessToken, Lenient)
+    Note right of K: signature + aud FIRST, label after.<br/>absent / JWT / at+jwt all pass
+    RS->>K: verify_claims_as(token, aud, AccessToken, Strict)
+    Note right of K: RFC 9068 §4 — ONLY at+jwt.<br/>absent and JWT are refused too
+    C->>K: verify_claims_as(id, client_id, Jwt, Lenient)
+    Note right of K: absent / JWT pass; at+jwt REFUSED
+    end
+```
+
+---
+
+## Two tokens, two audiences
+
+An **ID token** says *who signed in*. An **access token** says *what may be
+done*. They are not the same object with different fields:
+
+| | `aud` | `sub` |
+|---|---|---|
+| access token | the resource server (`client.audience`) | the **user** |
+| ID token | the **client** (`client.client_id`) | the user |
+
+A resource server handed an ID token simply fails to verify it — the audience
+does not match. That is the barrier, and it is why **`build_client` refuses a
+client whose `audience` equals its `client_id`**: the two tokens would then be
+addressed identically, and an access token would deserialise and verify as an
+ID token.
+
+---
+
+## Explicit token typing (RFC 9068)
+
+The audience split holds — but only for a verifier that checks the audience.
+RFC 9068 adds a structural label so it does not have to:
+
+> The resource server MUST verify that the `typ` header value is `at+jwt` or
+> `application/at+jwt` and reject tokens carrying any other value.
+
+### Issuing
+
+```rust
+let service = OAuthService::new(store, keys, issuer)
+    .with_explicit_typ();          // access tokens get `typ: at+jwt`
+```
+
+ID tokens keep `JWT` — OIDC registers no `typ` of its own for them — and **that
+difference is the point**: once typing is on, nothing wami signs as an access
+token can be read as an ID token.
+
+It is opt-in because every token wami issued before this carries `typ: JWT`, and
+a resource server pinning that value would break the moment the header changed.
+The default flips at the next major.
+
+### Verifying — three doors
+
+```rust
+use wami::wami::sts::jwt::{TokenType, TypePolicy};
+
+// 1. No typ examined, ever. The pre-RFC-9068 contract, unchanged.
+let claims: OAuthClaims = keys.verify_claims(&token, audience)?;
+
+// 2. Lenient — for a deployment mid-migration.
+let claims: OAuthClaims = keys.verify_claims_as(
+    &token, audience, TokenType::AccessToken, TypePolicy::Lenient)?;
+
+// 3. Strict — RFC 9068 §4 as written.
+let claims: OAuthClaims = keys.verify_claims_as(
+    &token, audience, TokenType::AccessToken, TypePolicy::Strict)?;
+```
+
+| policy | expecting | header says | |
+|---|---|---|---|
+| `Lenient` | `AccessToken` | absent, `JWT`, or `at+jwt` | accepted |
+| `Lenient` | `Jwt` | absent or `JWT` | accepted |
+| `Lenient` | `Jwt` | `at+jwt` | **refused** |
+| `Strict` | either | exactly the expected label | accepted |
+| either | either | anything unrecognised | refused |
+
+**Which to use.** `Lenient` while any issuer you accept still predates
+labelling — it already closes the direction that matters. `Strict` once they all
+label; until then it refuses your own legacy tokens, which is exactly why it is
+a choice and not a default.
+
+The signature and audience are checked **first**, always. The label is examined
+only once the token has proven genuine, so no decision rests on bytes an
+attacker chose.
+
+### Turning it on is not an outage
+
+A token minted before the flip carries `typ: JWT`, and `Lenient` verification —
+which is what `introspect_token` and `user_info` use — still accepts it. Nothing
+is reissued. Tokens in flight expire normally.
+
+---
+
+## Reporting the sign-in
+
+A relying party enforcing `max_age` needs `auth_time`; one that cares whether a
+password or a passkey was used needs `acr`/`amr`. wami cannot know any of it, so
+the host says:
+
+```rust
+use wami::wami::oauth::AuthenticationEvent;
+
+AuthorizationRequest {
+    // ...
+    event: Some(AuthenticationEvent {
+        at: signed_in_at,
+        acr: Some("urn:mace:incommon:iap:silver".to_string()),
+        amr: vec!["pwd".to_string(), "hwk".to_string()],   // RFC 8176
+    }),
+}
+```
+
+Omit it and the claims do not appear — in the struct or on the wire.
+
+### The event is carried, not recomputed
+
+OIDC Core §12.2:
+
+> if the ID Token contains an `auth_time` Claim, its value MUST represent the
+> time of the original authentication - not the time that the new ID token is
+> issued
+
+So the event travels into the refresh chain. A chain that forgot it would
+silently reset the user's session age on every refresh — precisely what an RP
+enforcing `max_age` is trying to detect.
+
+### One sign-in, one chain
+
+`acr`/`amr` stay fixed for the life of the chain. A user who signs in with a
+password and later adds a hardware key keeps reporting `amr: ["pwd"]` until the
+chain ends.
+
+That is not a gap: **a stronger authentication is a new authentication**, and the
+honest way to reflect it is a new authorization, which mints a new chain with a
+new event. An RP that needs a *fresh* assurance must ask for one, not trust a
+claim minted a month ago.
+
+---
+
+## Refresh rotation and leak detection
+
+A refresh token is **single-use**. Exchanging it spends it and issues a
+replacement.
+
+Presenting a spent token means it leaked — the legitimate client has already
+moved on to its replacement. wami revokes the entire chain for that user and
+client. **Both** the thief and the legitimate client are forced back through
+sign-in, because there is no way to tell them apart from here, and a silent
+second use is indistinguishable from theft.
+
+An **expiry** is not a leak, and is not punished that way: the token is refused,
+the chain is untouched, the user signs in again.
+
+### Withdrawing consent kills the chain
+
+```rust
+service.withdraw_consent("gallery", "alice").await?;
+```
+
+Revoking the consent alone would leave the client holding a refresh token that
+keeps minting access tokens for a month. The user would have said no and nothing
+would have stopped.
+
+---
+
+## Implementing a store
+
+Five traits, in `wami::store::traits::oauth`:
+
+| trait | holds |
+|---|---|
+| `OAuthClientStore` | registered clients |
+| `OAuthTokenStore` | issued access tokens, so they can be revoked |
+| `OAuthAuthorizationStore` | authorization codes |
+| `OAuthRefreshStore` | refresh tokens |
+| `OAuthConsentStore` | standing user consent |
+
+They carry the `OAuth` prefix because `ConsentStore` belongs to GDPR consent and
+`SessionStore` to STS — unrelated concepts that would otherwise collide.
+
+### Two contracts that are not optional
+
+**`consume_authorization_code` must be one operation.** Reading the code and
+then deleting it leaves a window in which two exchanges can both succeed —
+precisely the replay an authorization code exists to be immune to. If your
+backend cannot do it in one statement, use `DELETE ... RETURNING` or a
+transaction. Do not emulate it with a get followed by a delete.
+
+**`used_at` means "this token was spent", not "this token was shown to us".** It
+may only be stamped by a rotation that won, or by `revoke_refresh_chain`. A
+store that stamps it on a *failed* presentation — to record an attempt, say —
+turns every expired token into a reported leak and every idle user into a forced
+sign-out.
+
+`rotate_refresh_token` returns the record it took, so the caller can tell
+"unknown" from "expired" from "reused". When it cannot grant the rotation, it
+must return the existing record **unchanged** and persist nothing.
+
+### Not a transaction, on purpose
+
+`exchange_code` consumes the code in one operation and writes the tokens in
+another. A process that dies between the two leaves the code spent and no tokens
+issued: the exchange fails, the user signs in again. **That is the direction to
+fail in.** Minting first and consuming after turns the same crash into a code
+still redeemable after tokens were handed out.
+
+---
+
+## What is deliberately absent
+
+**No `plain` PKCE.** It defends against nothing: an attacker who intercepts the
+authorization request sees the challenge, and under `plain` the challenge *is*
+the verifier. It is absent from the code and from the discovery document.
+
+**PKCE is not optional.** `AuthorizationRequest::challenge` is a
+`CodeChallenge`, not an `Option<CodeChallenge>`. A caller cannot forget it.
+
+**No implicit flow.** `response_types_supported` is `["code"]`.
+
+**Redirect URIs match exactly, never by prefix.** A prefix match on
+`https://app.test/cb` accepts `https://app.test/cb.attacker.test`, which is how
+codes get delivered to the wrong party. An unregistered URI is an error to *the
+caller of this library*, never a redirect — sending an error to an unverified
+redirect URI is itself the vulnerability.
+
+**No `at_hash`.** OIDC Core §3.1.3.6 makes it OPTIONAL for a token-endpoint ID
+token in the code flow — REQUIRED only for front-channel delivery, which this
+library never does. And the spec derives its hash from `alg`, which for EdDSA no
+specification defines: implementations split between SHA-256 and Ed25519's
+internal SHA-512. An `at_hash` a relying party recomputes differently is a hard
+validation failure, where its absence is a no-op.
+
+**No `claims_supported` in discovery.** Advertising `auth_time`/`acr`/`amr`
+would be a claim wami cannot keep: whether they appear depends entirely on
+whether the host reports them, which is not knowable at discovery time.
+
+---
+
+## See also
+
+- [STS Guide](STS_GUIDE.md) — the same keyset, for temporary credentials
+- [SSO Admin Guide](SSO_ADMIN_GUIDE.md) — permission sets
+- [Store Implementation](STORE_IMPLEMENTATION.md) — persistence in general
+- [Security](SECURITY.md) — reporting a vulnerability

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Welcome to the WAMI documentation! Choose your path:
 - **[IAM Operations](IAM_GUIDE.md)** - Manage users, roles, policies, groups
 - **[STS Operations](STS_GUIDE.md)** - Get temporary credentials
 - **[SSO Admin](SSO_ADMIN_GUIDE.md)** - Configure permission sets
+- **[OAuth 2.0 & OIDC](OAUTH_OIDC_GUIDE.md)** - Issue tokens, sign users in
 - **[Multi-Tenant](MULTI_TENANT_GUIDE.md)** - Isolate resources by tenant
 
 ### Implement Advanced Features
@@ -43,6 +44,9 @@ Welcome to the WAMI documentation! Choose your path:
 ### Use Case: Generating Temporary Access Keys
 → Start with [STS Guide](STS_GUIDE.md)
 
+### Use Case: Letting Users Sign In to Your Applications
+→ Start with [OAuth 2.0 & OIDC Guide](OAUTH_OIDC_GUIDE.md)
+
 ## 📖 Full Documentation
 
 | Document | Description | Audience |
@@ -51,6 +55,7 @@ Welcome to the WAMI documentation! Choose your path:
 | [IAM Guide](IAM_GUIDE.md) | Complete IAM operations | Developers |
 | [STS Guide](STS_GUIDE.md) | Temporary credentials | Developers |
 | [SSO Admin Guide](SSO_ADMIN_GUIDE.md) | SSO configuration | Developers |
+| [OAuth & OIDC Guide](OAUTH_OIDC_GUIDE.md) | Authorization server, OpenID Provider | Developers |
 | [Multi-Tenant](MULTI_TENANT_GUIDE.md) | Tenant isolation | SaaS Builders |
 | [Multicloud Providers](MULTICLOUD_PROVIDERS.md) | Cloud abstraction | Platform Teams |
 | [Store Implementation](STORE_IMPLEMENTATION.md) | Custom persistence | Backend Developers |


### PR DESCRIPTION
Closes #125. Both gaps came out of the adversarial review of #119 — the parts that were real but too broad for that PR.

## `typ: at+jwt` — RFC 9068

An access token and an ID token were told apart only by `aud`. That holds, but only for a verifier that checks the audience. RFC 9068 adds a label a resource server can refuse on directly:

> The resource server MUST verify that the `typ` header value is `at+jwt` or `application/at+jwt` and reject tokens carrying any other value.

`KeyManager` gains `TokenType`, `sign_claims_as` and `verify_claims_as`. ID tokens keep `JWT` — OIDC registers no `typ` of its own for them — and **that difference is the point**: once typing is on, nothing wami signs as an access token can be read as an ID token.

### The asymmetry is what makes it safe to turn on

A token may be labelled *less* specifically than expected, never differently:

| expecting | header says | |
|---|---|---|
| access token | absent, `JWT`, or `at+jwt` | accepted |
| ID token | absent or `JWT` | accepted |
| ID token | `at+jwt` | **refused** |
| either | anything else | refused |

So flipping `with_explicit_typ()` in production does not invalidate a single token in flight — a test constructs a service with the flag on, points it at tokens minted by a service with the flag off, and asserts introspection and `/userinfo` still accept them. Nothing is reissued.

Issuance stays opt-in because every token wami has issued so far carries `typ: JWT`, and a resource server pinning that value would break the moment the header changed. The default flips at the next major.

## `auth_time`, `acr`, `amr`

An RP enforcing `max_age` needs `auth_time`; one that cares whether a password or a passkey was used needs `acr`/`amr`. wami cannot know any of it — the host authenticates, not the library.

```rust
AuthorizationRequest {
    // ...
    event: Some(AuthenticationEvent {
        at: signed_in_at,
        acr: Some("urn:mace:incommon:iap:silver".into()),
        amr: vec!["pwd".into(), "hwk".into()],
    }),
}
```

Omit it and the claims do not appear — in the struct or on the wire, asserted.

### The event travels; it is not recomputed

OIDC Core §12.2:

> if the ID Token contains an `auth_time` Claim, its value MUST represent the time of the original authentication - not the time that the new ID token is issued

So the event is carried in the `RefreshToken` record. A chain that forgot it would silently reset the user's session age on every refresh — precisely what an RP enforcing `max_age` is trying to detect. A test chains two consecutive refreshes and asserts `auth_time` and `amr` survive both, and that the nonce does not (§12.2 again: a refreshed ID token "SHOULD NOT have a nonce Claim").

## Breaking

`AuthorizationCode`, `RefreshToken`, `AuthorizationRequest` and `IdTokenRequest` each gain an `event` field. Store implementers constructing them literally need `event: None`. Both persisted structs carry `#[serde(default)]`, so records already in a database deserialise unchanged.

## Deliberately not done

**`at_hash`.** OIDC Core §3.1.3.6 makes it OPTIONAL for a token-endpoint ID token in the code flow — REQUIRED only for front-channel delivery, which this library never does. And the spec derives the hash from `alg`, which for EdDSA no specification defines: implementations split between SHA-256 and Ed25519's internal SHA-512. An `at_hash` a relying party recomputes differently is a hard validation failure where absence is a no-op. The reasoning is written into `wami/oauth/oidc.rs` so it is not "fixed" later.

**`claims_supported` in discovery.** Advertising `auth_time`/`acr`/`amr` would be a claim wami cannot keep — whether they appear depends entirely on whether the host reports them, which is not knowable at discovery time.

## Verification

- `cargo test --workspace` — 25 suites, all green
- `cargo clippy --all-targets --all-features` — 0 warnings
- `RUSTDOCFLAGS=-D warnings cargo doc` — clean
- Examples 27 and 28 run clean; 28 now shows both features, including that a verifier of access tokens has to say so once they are labelled
- Coverage on changed code: **99.4%** lines in the OIDC service, **100%** in the domain, **97.9%** in `sts/jwt` (its misses are pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)