### PR TITLE
chore: make the four surviving crates publishable

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,3 +1,6 @@
 {
-  "crates/wami": "0.16.0"
+  "crates/wami": "0.16.0",
+  "crates/wami-core": "0.16.0",
+  "crates/wami-condition": "0.16.0",
+  "crates/wami-macros": "0.16.0"
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1084,7 +1084,7 @@ dependencies = [
 
 [[package]]
 name = "wami-condition"
-version = "0.1.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "serde",
@@ -1094,7 +1094,7 @@ dependencies = [
 
 [[package]]
 name = "wami-core"
-version = "0.1.0"
+version = "0.16.0"
 dependencies = [
  "chrono",
  "serde",
@@ -1104,7 +1104,7 @@ dependencies = [
 
 [[package]]
 name = "wami-macros"
-version = "0.1.0"
+version = "0.16.0"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/crates/wami-condition/Cargo.toml
+++ b/crates/wami-condition/Cargo.toml
@@ -1,16 +1,23 @@
 [package]
 name = "wami-condition"
-version = "0.1.0"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
-description = "Policy condition key evaluation for WAMI"
+description = "IAM policy condition key evaluation, as used by wami"
+rust-version = "1.90.0"
+repository = "https://github.com/Lsh0x/wami"
+homepage = "https://github.com/Lsh0x/wami"
+documentation = "https://docs.rs/wami-condition"
+readme = "README.md"
+keywords = ["iam", "policy", "authorization", "conditions"]
+categories = ["authentication", "parser-implementations"]
 authors = ["LSH <github@lsh.tech>"]
 
 [dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
-wami-core = { path = "../wami-core" }
+wami-core = { path = "../wami-core", version = "0.16.0" }
 
 [dev-dependencies]
 

--- a/crates/wami-condition/README.md
+++ b/crates/wami-condition/README.md
@@ -1,0 +1,60 @@
+# wami-condition
+
+IAM policy **condition key** evaluation — the `Condition` block of a policy
+statement, decided against a request context.
+
+[![crates.io](https://img.shields.io/crates/v/wami-condition.svg)](https://crates.io/crates/wami-condition)
+[![docs.rs](https://docs.rs/wami-condition/badge.svg)](https://docs.rs/wami-condition)
+
+Extracted from [`wami`](https://crates.io/crates/wami), which uses it to decide
+whether a statement applies. It is published separately because deciding a
+condition block is a self-contained problem: you can use it against your own
+policy documents without adopting an identity model.
+
+```toml
+[dependencies]
+wami-condition = "0.16"
+```
+
+## What it evaluates
+
+A condition block maps an operator to the keys it constrains:
+
+```json
+{
+  "StringEquals":   { "aws:PrincipalAccount": "123456789012" },
+  "Bool":           { "aws:SecureTransport": "true" },
+  "DateLessThan":   { "aws:CurrentTime": "2026-12-31T23:59:59Z" }
+}
+```
+
+`evaluate_condition_block` answers whether the whole block holds for a given
+[`ConditionContext`]. Every operator family from the AWS condition grammar is
+implemented — `String*`, `Numeric*`, `Date*`, `Bool`, `IpAddress`, `Arn*`,
+`Binary*` — each with its `Not` and `IfExists` variants, and `ForAllValues` /
+`ForAnyValue` set qualifiers.
+
+## The part that is easy to get wrong
+
+`IfExists` is not "optional". `StringEqualsIfExists` passes when the key is
+**absent**, and is only checked when the key is present — which means adding
+`IfExists` to a `Deny` can turn a rule that blocked something into one that
+permits it. The distinction is implemented, and tested.
+
+Likewise an absent key under a plain operator makes the condition **fail**, not
+succeed: a statement that cannot be evaluated does not apply.
+
+## Context keys
+
+The `aws:` keys are recognised natively — `PrincipalArn`, `PrincipalAccount`,
+`PrincipalType`, `CurrentTime`, `EpochTime`, `SecureTransport`,
+`MultiFactorAuthPresent`, `MultiFactorAuthAge`, `RequestedRegion`,
+`ResourceArn`, `ResourceAccount`, `Referer` and more. Any key the table does
+not name falls through to `ConditionContext::custom_values`, so your own keys
+work by putting them there — no registration step.
+
+## License
+
+MIT. See [LICENSE](https://github.com/Lsh0x/wami/blob/main/LICENSE).
+
+[`ConditionContext`]: https://docs.rs/wami-condition/latest/wami_condition/context/struct.ConditionContext.html

--- a/crates/wami-core/Cargo.toml
+++ b/crates/wami-core/Cargo.toml
@@ -1,9 +1,17 @@
 [package]
 name = "wami-core"
-version = "0.1.0"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
-description = "Core primitives shared across the WAMI workspace"
+description = "Core primitives for wami: ARNs, contexts, errors and shared types"
+authors = ["LSH <github@lsh.tech>"]
+rust-version = "1.90.0"
+repository = "https://github.com/Lsh0x/wami"
+homepage = "https://github.com/Lsh0x/wami"
+documentation = "https://docs.rs/wami-core"
+readme = "README.md"
+keywords = ["iam", "identity", "arn", "multicloud"]
+categories = ["api-bindings", "authentication"]
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/wami-macros/Cargo.toml
+++ b/crates/wami-macros/Cargo.toml
@@ -1,9 +1,16 @@
 [package]
 name = "wami-macros"
-version = "0.1.0"
+version = "0.16.0"
 edition = "2021"
 license = "MIT"
-description = "Procedural macros for WAMI, the multi-cloud IAM library"
+description = "Procedural macros for wami, the multicloud IAM library"
+authors = ["LSH <github@lsh.tech>"]
+rust-version = "1.90.0"
+homepage = "https://github.com/Lsh0x/wami"
+documentation = "https://docs.rs/wami-macros"
+readme = "README.md"
+keywords = ["iam", "macros", "derive"]
+categories = ["development-tools::procedural-macro-helpers"]
 repository = "https://github.com/Lsh0x/wami"
 
 [lib]

--- a/crates/wami-macros/README.md
+++ b/crates/wami-macros/README.md
@@ -5,7 +5,7 @@ for service implementations and service registration.
 
 ## Macros
 
-- `#[derive(Service)]` – Derive the `wami_traits::Service` trait for a struct.
+- `#[derive(Service)]` – Derive the `wami_core::traits::Service` trait for a struct.
 - `#[service]` – Attribute macro that generates standard service boilerplate
   (constructor, store helpers) with support for composite trait bounds and an
   optional `generate_new = false` flag.
@@ -23,7 +23,7 @@ wami-macros = { path = "../wami-macros" }
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use wami_macros::service;
-use wami_traits::Service;
+use wami_core::traits::Service;
 
 pub trait UserServiceStore: wami::store::traits::UserStore {}
 impl<T> UserServiceStore for T where T: wami::store::traits::UserStore {}

--- a/crates/wami-service/Cargo.toml
+++ b/crates/wami-service/Cargo.toml
@@ -4,6 +4,10 @@ version = "0.1.0"
 edition = "2021"
 license = "MIT"
 description = "Service registry and orchestration utilities for the WAMI workspace"
+# Not in `wami`\'s dependency graph, so nothing forces it onto crates.io.
+# Saying so explicitly stops a stray `cargo publish --workspace` from
+# minting a public name for something nobody asked for.
+publish = false
 
 [dependencies]
 wami-core = { path = "../wami-core" }

--- a/crates/wami-service/README.md
+++ b/crates/wami-service/README.md
@@ -16,13 +16,13 @@ trait-object interface.
 ```toml
 [dependencies]
 wami-service = { path = "../wami-service" }
-wami-traits = { path = "../wami-traits" }
+wami-core = { path = "../wami-core" }
 ```
 
 ```rust
 use std::sync::Arc;
 use wami_service::Registry;
-use wami_traits::{Service, ServiceRegistry};
+use wami_core::traits::{Service, ServiceRegistry};
 
 #[derive(Default)]
 struct EchoService;

--- a/crates/wami/Cargo.toml
+++ b/crates/wami/Cargo.toml
@@ -34,9 +34,9 @@ getrandom = "0.2"
 ed25519-dalek = { version = "2", features = ["rand_core", "pkcs8"], optional = true }
 jsonwebtoken = { version = "9", optional = true }
 roxmltree = "0.21"
-wami-condition = { path = "../wami-condition" }
-wami-core = { path = "../wami-core" }
-wami-macros = { path = "../wami-macros" }
+wami-condition = { path = "../wami-condition", version = "0.16.0" }
+wami-core = { path = "../wami-core", version = "0.16.0" }
+wami-macros = { path = "../wami-macros", version = "0.16.0" }
 
 [features]
 # Provider translations, forwarded to wami-core. Off by default there, so off

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -31,20 +31,22 @@ WAMI (Who Am I) is a **domain-driven**, cloud-agnostic Identity and Access Manag
 ┌────────────────────────────┼──────────────────────────────────┐
 │                    Workspace Crates                           │
 │                                                               │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌──────────┐  │
-│  │ wami-core│  │wami-traits│ │wami-pro  │  │wami-macros│  │
-│  │  ARN     │  │  Store    │  │  vider   │  │  Service │  │
-│  │ Context  │  │  Service  │  │  AWS/GCP │  │  derive  │  │
-│  │  Error   │  │ Registry  │  │  Azure   │  │  macros  │  │
-│  └──────────┘  └──────────┘  └──────────┘  └──────────┘  │
-│       │              │              │              │       │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐              │
-│  │wami-ident│  │wami-cred  │  │wami-serv │              │
-│  │   ity    │  │  entials  │  │   ice    │              │
-│  │ User     │  │ AccessKey │  │ Registry │              │
-│  │ Group    │  │ MFA       │  │          │              │
-│  │ Role     │  │ Login     │  │          │              │
-│  └──────────┘  └──────────┘  └──────────┘              │
+│   ┌───────────┐   ┌────────────────┐   ┌─────────────┐        │
+│   │ wami-core │   │ wami-condition │   │ wami-macros │        │
+│   │   ARN     │   │  Condition key │   │   #[service]│        │
+│   │  Context  │   │   evaluation   │   │   derive    │        │
+│   │   Error   │   │                │   │             │        │
+│   │  traits   │   │                │   │             │        │
+│   └───────────┘   └────────────────┘   └─────────────┘        │
+│         │                  │                   │              │
+│         └──────────────────┴───────────────────┘              │
+│                            │                                  │
+│                    ┌───────────────┐                          │
+│                    │     wami      │                          │
+│                    │  identity ·  policies · STS              │
+│                    │  OAuth/OIDC · provider · credentials      │
+│                    │  services · stores                       │
+│                    └───────────────┘                          │
 └────────────────────────────┬──────────────────────────────────┘
                              │
 ┌────────────────────────────┼──────────────────────────────────┐

--- a/docs/MIGRATION_WORKSPACE.md
+++ b/docs/MIGRATION_WORKSPACE.md
@@ -1,5 +1,10 @@
 # Workspace Migration Summary
 
+> **Historical.** This records the split *into* a workspace. The shape has
+> changed since: six of those crates were folded back into `wami` so it could
+> be published at all. See [#129](https://github.com/Lsh0x/wami/issues/129)
+> and [WORKSPACE_STRUCTURE.md](WORKSPACE_STRUCTURE.md) for what exists today.
+
 This document summarizes the migration from a monolithic crate structure to a modular workspace architecture.
 
 ## Migration Date

--- a/docs/WORKSPACE_STRUCTURE.md
+++ b/docs/WORKSPACE_STRUCTURE.md
@@ -13,197 +13,46 @@ WAMI is organized as a **Cargo workspace** containing multiple crates, each with
 
 ## Workspace Crates
 
-### Core Crates
+Five members. Four are published to crates.io; the fifth is internal.
 
-#### `wami-core`
-**Purpose**: Foundation primitives shared across the entire workspace
+| crate | published | what it is |
+|-------|-----------|------------|
+| [`wami`](../crates/wami) | ✅ | the library — identity, policies, STS, OAuth/OIDC, stores, services, and the provider and credential modules |
+| [`wami-core`](../crates/wami-core) | ✅ | ARNs, `WamiContext`, `AmiError`, shared types, and the `traits` module (`Store`, `Service`, `ServiceRegistry`) |
+| [`wami-condition`](../crates/wami-condition) | ✅ | IAM condition-key evaluation — self-contained enough to use on its own |
+| [`wami-macros`](../crates/wami-macros) | ✅ | procedural macros. Separate because Rust requires it: a `proc-macro = true` crate cannot hold ordinary library code |
+| [`wami-service`](../crates/wami-service) | ❌ | a service registry, not in `wami`'s dependency graph. `publish = false` |
 
-**Contains**:
-- `arn` - ARN parsing, building, and transformation
-- `context` - `WamiContext` and session information
-- `error` - `AmiError` and `Result` types
-- `types` - Common types (`PolicyDocument`, `Tag`, etc.)
-
-**Usage**:
-```rust
-use wami_core::arn::{WamiArn, Service, TenantPath};
-use wami_core::context::WamiContext;
-use wami_core::error::{AmiError, Result};
-use wami_core::types::PolicyDocument;
+```
+wami-core ──┬── wami-condition ──┐
+            ├── wami-service     ├── wami
+wami-macros ────────────────────-┘
 ```
 
-**Dependencies**: AWS SDKs, `chrono`, `serde`, `thiserror`
+### Why so few
 
----
+There were ten. Publishing `wami` requires every crate in its graph to be on
+crates.io — cargo strips `path` at publish time, so a consumer resolves
+`wami-core = "0.16.0"` from the registry and nothing else. Six of the ten had no
+public identity to justify that: `wami-provider` and the four cloud
+implementations existed only behind a re-export façade, `wami-credentials`
+behind `pub use wami_credentials as credentials`, and `wami-traits` was 37 lines
+that `wami` never referenced.
 
-#### `wami-traits`
-**Purpose**: Domain-agnostic trait definitions for stores and services
+They are now modules — `wami::provider`, `wami::provider::aws`,
+`wami::credentials`, `wami_core::traits` — at exactly the paths they were
+reachable from before. See [#129](https://github.com/Lsh0x/wami/issues/129) for
+the reasoning and what it cost.
 
-**Contains**:
-- `Store<T>` - Generic CRUD trait for backing stores
-- `Service` - Abstraction over high-level services
-- `ServiceRegistry` - Dependency injection mechanism
+`wami-condition` stayed separate on purpose: 10k lines that rarely change, whose
+separate compilation is worth keeping, and a problem someone might genuinely
+want to solve without adopting an identity model.
 
-**Usage**:
-```rust
-use wami_traits::Store;
-use wami_traits::Service;
-use wami_traits::ServiceRegistry;
-```
+### Versioning
 
-**Dependencies**: `wami-core`
-
----
-
-#### `wami-provider`
-**Purpose**: Cloud provider abstraction layer
-
-**Contains**:
-- `CloudProvider` trait definition
-- Provider configuration structures (`ProviderConfig`, `ResourceLimits`, `ResourceType`)
-- ARN builder utilities
-- Provider registry for runtime loading
-
-**Usage**:
-```rust
-use wami_provider::{CloudProvider, ProviderConfig, ResourceType};
-```
-
-**Dependencies**: `wami-core`
-
-**Note**: Concrete provider implementations live in separate crates under `crates/cloud-provider/`:
-- `wami-provider-aws` - AWS provider implementation
-- `wami-provider-gcp` - Google Cloud Platform provider implementation
-- `wami-provider-azure` - Microsoft Azure provider implementation
-- `wami-provider-custom` - Custom provider builder for on-premise or other clouds
-
-**Provider Crate Usage**:
-```rust
-use wami_provider::CloudProvider;
-use wami_provider_aws::AwsProvider;
-
-let provider = AwsProvider::new();
-let arn = provider.generate_resource_identifier(
-    wami_provider::ResourceType::User,
-    "123456789012",
-    "/",
-    "alice",
-);
-```
-
----
-
-### Domain Crates
-
-#### `wami-identity`
-**Purpose**: Identity domain models and builders
-
-**Contains**:
-- `User`, `Group`, `Role`
-- `IdentityProvider`, `ServiceLinkedRole`
-- Builders and operations for identity management
-
-**Usage**:
-```rust
-use wami_identity::{User, Group, Role, UserBuilder};
-```
-
-**Dependencies**: `wami-core`
-
----
-
-#### `wami-credentials`
-**Purpose**: Credential management domain
-
-**Contains**:
-- `AccessKey`, `LoginProfile`, `MfaDevice`
-- `ServerCertificate`, `SigningCertificate`
-- Service-specific credentials
-
-**Usage**:
-```rust
-use wami_credentials::{AccessKey, LoginProfile, MfaDevice};
-```
-
-**Dependencies**: `wami-core`
-
----
-
-### Infrastructure Crates
-
-#### `wami-macros`
-**Purpose**: Procedural macros for reducing boilerplate
-
-**Contains**:
-- `#[derive(Service)]` - Auto-generate `Service` trait implementations
-- `#[service]` - Generate service struct boilerplate
-- `register_services!` - Register multiple services in a registry
-
-**Usage**:
-```rust
-use wami_macros::service;
-
-#[service(store_trait = "crate::store::traits::UserStore")]
-pub struct UserService<S> {
-    store: Arc<RwLock<S>>,
-}
-```
-
-**Dependencies**: `syn`, `quote`, `proc-macro2`
-
-**Note**: This is a procedural macro crate (`proc-macro = true`)
-
----
-
-#### `wami-service`
-**Purpose**: Service registry and orchestration utilities
-
-**Contains**:
-- `Registry` - Dynamic service registration and retrieval
-- Service discovery utilities
-
-**Usage**:
-```rust
-use wami_service::Registry;
-use wami_traits::ServiceRegistry;
-
-let mut registry = Registry::new();
-registry.register("user_service", Arc::new(user_service));
-```
-
-**Dependencies**: `wami-traits`
-
----
-
-### Main Crate
-
-#### `wami`
-**Purpose**: Main façade crate that re-exports everything
-
-**Contains**:
-- Re-exports from all workspace crates
-- Service layer implementations
-- Store implementations (memory, traits)
-- Backward compatibility layer
-
-**Usage**:
-```rust
-// All public APIs are available through the main crate
-use wami::{
-    // Core types
-    WamiContext, WamiArn, AmiError, Result,
-    // Domain types
-    User, Group, Role, AccessKey,
-    // Stores
-    InMemoryStore, UserStore,
-    // Services
-    UserService, GroupService,
-};
-```
-
-**Dependencies**: All workspace crates
-
----
+`wami`, `wami-core`, `wami-condition` and `wami-macros` move in lockstep at one
+version. They are released together and tested together; separate version lines
+would imply an independence that does not exist.
 
 ## Import Patterns
 
@@ -303,7 +152,7 @@ cargo build --workspace
 ### Build specific crate
 ```bash
 cargo build -p wami-core
-cargo build -p wami-identity
+cargo build -p wami-condition
 ```
 
 ### Build with tests
@@ -313,10 +162,12 @@ cargo test --workspace
 
 ## Development Workflow
 
-1. **Core changes** → Edit `wami-core`
-2. **Domain changes** → Edit `wami-identity`, `wami-credentials`, etc.
-3. **Service changes** → Edit `wami` crate's service layer
-4. **Macro changes** → Edit `wami-macros` (requires full rebuild)
+1. **Core changes** → Edit `wami-core` (ARNs, context, errors, shared traits)
+2. **Condition evaluation** → Edit `wami-condition`
+3. **Everything else** → Edit `wami`: domain, services, stores, providers,
+   credentials. They are modules there, not crates.
+4. **Macro changes** → Edit `wami-macros` (requires a full rebuild, since every
+   expansion downstream is invalidated)
 
 ## Migration Guide
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,6 +8,30 @@
       "bump-minor-pre-major": true,
       "draft": false,
       "prerelease": false
+    },
+    "crates/wami-core": {
+      "release-type": "rust",
+      "package-name": "wami-core",
+      "include-component-in-tag": true,
+      "bump-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false
+    },
+    "crates/wami-condition": {
+      "release-type": "rust",
+      "package-name": "wami-condition",
+      "include-component-in-tag": true,
+      "bump-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false
+    },
+    "crates/wami-macros": {
+      "release-type": "rust",
+      "package-name": "wami-macros",
+      "include-component-in-tag": true,
+      "bump-minor-pre-major": true,
+      "draft": false,
+      "prerelease": false
     }
   },
   "changelog-sections": [
@@ -45,6 +69,20 @@
       "type": "chore",
       "section": "Chores",
       "hidden": true
+    }
+  ],
+  "separate-pull-requests": false,
+  "group-pull-request-title-pattern": "chore(main): release ${version}",
+  "plugins": [
+    {
+      "type": "linked-versions",
+      "groupName": "wami",
+      "components": [
+        "wami",
+        "wami-core",
+        "wami-condition",
+        "wami-macros"
+      ]
     }
   ]
 }


### PR DESCRIPTION
Step 4 of #129 — the last one before anything can reach crates.io.

## Versions beside the paths

`cargo publish` rejects a path dependency with no version, because it strips `path` and leaves the consumer resolving from the registry:

```toml
wami-core = { path = "../wami-core", version = "0.16.0" }
```

The path is what builds here; the version is what a consumer gets.

## One version, not four

All four move together at **0.16.0**. They are released together and tested together — separate version lines would advertise an independence that does not exist, and leave someone guessing which `wami-core` goes with which `wami`.

release-please now knows all four, with a `linked-versions` plugin so they bump as a group and produce a single release PR. Only `crates/wami` keeps `include-component-in-tag: false`; the other three carry their name in the tag, since **four packages claiming `v0.16.0` would collide**.

`wami-service` gets `publish = false` — a workspace member outside `wami`'s graph, so nothing forces it onto crates.io. Saying so stops a stray `cargo publish --workspace` from minting a public name nobody asked for.

## Publishing metadata

The three had a name, a version and a licence and nothing else. They now carry repository, homepage, documentation, keywords, categories, authors and MSRV — and a `readme` pointing at a file that **exists**, which is the bug that already bit `wami` once this week.

`wami-condition` had no README. It has one now, and its claims were checked against the code rather than assumed:

- `StringEqualsIfExists` passes when the key is **absent**; a plain operator **fails** on one. Adding `IfExists` to a `Deny` can therefore turn a rule that blocked something into one that permits it — worth saying out loud.
- unrecognised keys fall through to `ConditionContext::custom_values`

Both turn out to be pinned by tests that already existed (`test_string_equals_missing_key`, `test_string_equals_if_exists_missing_key`).

`cargo package` verified for all four: **23, 12, 10 and 306 files**.

## Docs the refactor had made false

| doc | what happened |
|---|---|
| `WORKSPACE_STRUCTURE.md` | described ten crates, three of which no longer exist. Rewritten around the five that do, with *why* there are so few. |
| `ARCHITECTURE.md` | diagram redrawn |
| `MIGRATION_WORKSPACE.md` | a historical record, so it keeps its content — with a note at the top that the shape has changed since, pointing at what exists today |

The stale `wami_traits::` references in the `wami-macros` and `wami-service` READMEs are fixed too, leftovers from #130.

## After this

The graph is publishable. What remains in #129 is step 5 — publishing in dependency order (`wami-core` → `wami-condition` → `wami-macros` → `wami`), which is irreversible and yours to trigger.

## Verification

- 1576 tests pass, unchanged
- clippy `--workspace --all-targets --all-features`: 0 warnings
- both JSON config files parse

🤖 Generated with [Claude Code](https://claude.com/claude-code)