### PR TITLE
ci: let release-please rewrite the versions crates use for each other

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -74,6 +74,7 @@
   "separate-pull-requests": false,
   "group-pull-request-title-pattern": "chore(main): release ${version}",
   "plugins": [
+    "cargo-workspace",
     {
       "type": "linked-versions",
       "groupName": "wami",


### PR DESCRIPTION
The release for #137 was computed, written and pushed, and never became a pull
request. Two things were in the way, and the first hid the second.

**GitHub Actions was not permitted to open pull requests.** The run ended on
`GitHub Actions is not permitted to create or approve pull requests` — after
doing all the work. The branch `release-please--branches--main` has existed
since, holding a complete release nobody could see. That setting is now changed,
which is what let the real fault surface.

**`linked-versions` does not touch the version each crate states for the
others.** It keeps the four on one number, so the release branch bumped the
packages to `0.17.0` and left this behind, in two files:

```toml
wami-core = { path = "../wami-core", version = "0.16.0" }
```

and `cargo` refused the workspace it was handed:

```
error: failed to select a version for the requirement `wami-core = "^0.16.0"`
candidate versions found which didn't match: 0.17.0
required by package `wami-condition v0.17.0`
```

## The change

One line: `cargo-workspace` is added ahead of `linked-versions` in `plugins`.
That plugin exists for this — it rewrites members' dependencies on each other
and refreshes `Cargo.lock`. It runs first; `linked-versions` still decides the
number.

Four declarations are affected across two files, and none can simply lose its
`version`: path-only dependencies are not publishable, and #132 made these
crates publishable on purpose.

## Why it is worth a commit rather than a nudge

This is not a one-off. Every release from here would have failed the same way
once the permission was granted, and it would have failed with an error about a
version requirement rather than about the thing that produced it — which is the
kind of message that sends whoever reads it to edit a `Cargo.toml` by hand and
call it done.

## After this merges

The push to `main` re-runs Release Please, which should regenerate the release
branch with the dependency lines rewritten and open the PR for `0.17.0` across
all four crates. That is the release `anatta-auth` is waiting on: it is pinned
to `v0.16.0` and cannot take `seed_roles` until `0.17.0` exists.

I could not verify the `cargo-workspace` + `linked-versions` combination other
than by reading the plugin's documented behaviour — the run on `main` is the
first real test of it. If it conflicts, the fallback is `cargo-workspace` alone,
which also keeps a Rust workspace on one version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
