### PR TITLE
ci: stop hand-writing the release title release-please has to read back

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -72,7 +72,6 @@
     }
   ],
   "separate-pull-requests": false,
-  "group-pull-request-title-pattern": "chore(main): release ${version}",
   "plugins": [
     "cargo-workspace",
     {


### PR DESCRIPTION
`0.17.0` was tagged three times out of four, and its pull request sat on
`autorelease: pending` until the title was edited by hand. The log says why:

```
⚠ pullRequestTitlePattern miss the part of '${scope}'
⚠ pullRequestTitlePattern miss the part of '${component}'
✖ Bad pull request title: 'chore(main): release'
```

The same action writes that title and later parses it back to decide what to
release. `group-pull-request-title-pattern` was set to
`chore(main): release ${version}` — with `(main)` written out where the parser
expects `${scope}`, and no `${component}` at all. Generation dropped the
version and produced `chore(main): release`; parsing then rejected the very
title the generator had just written, and the releases were never built.

## Why removing it rather than correcting it

A hand-written pattern is a second copy of a format the tool already owns on
both sides, and the failure was the two copies disagreeing. Correcting the
pattern leaves two copies and a promise to keep them aligned. With no pattern,
one built-in default does both jobs and cannot disagree with itself.

## Not a one-off

**#140 is open right now** carrying the same titleless form, so the next
release would have stopped in exactly the same place. It should retitle itself
once this lands.

## Done alongside

`wami-macros-v0.17.0` is tagged and released by hand, on `515d9a1` with the
other three. The crate was already at `0.17.0` on `main` and in
`.release-please-manifest.json`; only its tag and release were missing, because
the run stopped after the third.

## Sequence, for the record

Three separate faults were stacked here, and each hid the next:

1. GitHub Actions was not permitted to open pull requests, so the release for
   #137 was computed, written, pushed — and invisible.
2. `linked-versions` did not rewrite the versions the crates state for each
   other, so `cargo` refused the workspace (#139 added `cargo-workspace`).
3. This one.

Only the first announced itself clearly. The second failed on a version
requirement rather than on what produced it, and the third looked like a
successful run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
