### PR TITLE
refactor!: a space was a tenant, and three actions had two names

### DIFF
--- a/crates/wami-core/src/actions.rs
+++ b/crates/wami-core/src/actions.rs
@@ -54,8 +54,15 @@ pub enum WamiAction {
     TenantConfigure,
     /// Manage tenant members (add, remove, ban)
     TenantManageMembers,
-    /// Suspend / reactivate a tenant
+    /// Suspend a tenant
+    ///
+    /// Its opposite is `TenantResume` and not this: cutting access off and
+    /// giving it back are not one permission. A tenant is usually suspended
+    /// FOR a reason — unpaid, abusive, breached — and whoever may cut it off is
+    /// not automatically whoever may decide the reason has passed.
     TenantSuspend,
+    /// Lift a suspension
+    TenantResume,
     /// List all tenants (platform-level)
     TenantList,
 
@@ -100,9 +107,14 @@ pub enum WamiAction {
     IamReadRole,
     /// Assume IAM role
     IamAssumeRole,
-    /// Create / attach IAM policy
+    /// Create an IAM policy
+    ///
+    /// Attaching it is `IamAttachPolicy`, which exists. Saying both here would
+    /// make that one grant nothing anybody could not already do.
     IamCreatePolicy,
-    /// Delete / detach IAM policy
+    /// Delete an IAM policy
+    ///
+    /// Detaching it is `IamDetachPolicy`, for the same reason.
     IamDeletePolicy,
     /// Read IAM policy
     IamReadPolicy,
@@ -352,6 +364,7 @@ impl WamiAction {
             Self::TenantConfigure => "tenant:Configure",
             Self::TenantManageMembers => "tenant:ManageMembers",
             Self::TenantSuspend => "tenant:Suspend",
+            Self::TenantResume => "tenant:Resume",
             Self::TenantList => "tenant:List",
             // Tenant
             Self::TenantRead => "tenant:Read",
@@ -453,6 +466,7 @@ impl WamiAction {
             | Self::TenantConfigure
             | Self::TenantManageMembers
             | Self::TenantSuspend
+            | Self::TenantResume
             | Self::TenantList
             | Self::TenantRead
             | Self::TenantUpdate
@@ -581,6 +595,7 @@ impl FromStr for WamiAction {
             ("tenant", "Configure") => Ok(Self::TenantConfigure),
             ("tenant", "ManageMembers") => Ok(Self::TenantManageMembers),
             ("tenant", "Suspend") => Ok(Self::TenantSuspend),
+            ("tenant", "Resume") => Ok(Self::TenantResume),
             ("tenant", "List") => Ok(Self::TenantList),
             ("tenant", "Read") => Ok(Self::TenantRead),
             ("tenant", "Update") => Ok(Self::TenantUpdate),
@@ -802,7 +817,8 @@ static REGISTRY: LazyLock<Vec<ActionInfo>> = LazyLock::new(|| {
             "tenant",
         ),
         ai("tenant:ManageMembers", "Manage tenant members", "tenant"),
-        ai("tenant:Suspend", "Suspend / reactivate a tenant", "tenant"),
+        ai("tenant:Suspend", "Suspend a tenant", "tenant"),
+        ai("tenant:Resume", "Lift a tenant suspension", "tenant"),
         ai("tenant:List", "List all tenants (platform-level)", "tenant"),
         ai("tenant:Read", "Read tenant info", "tenant"),
         ai("tenant:Update", "Update tenant", "tenant"),
@@ -1071,6 +1087,7 @@ mod tests {
             WamiAction::TenantConfigure,
             WamiAction::TenantManageMembers,
             WamiAction::TenantSuspend,
+            WamiAction::TenantResume,
             WamiAction::TenantList,
             // Tenant
             WamiAction::TenantRead,
@@ -1237,6 +1254,7 @@ mod tests {
             (WamiAction::TenantConfigure, WamiServicePrefix::Tenant),
             (WamiAction::TenantManageMembers, WamiServicePrefix::Tenant),
             (WamiAction::TenantSuspend, WamiServicePrefix::Tenant),
+            (WamiAction::TenantResume, WamiServicePrefix::Tenant),
             (WamiAction::TenantList, WamiServicePrefix::Tenant),
             (WamiAction::TenantRead, WamiServicePrefix::Tenant),
             (WamiAction::TenantUpdate, WamiServicePrefix::Tenant),
@@ -1385,6 +1403,7 @@ mod tests {
             "tenant:ManageMembers"
         );
         assert_eq!(WamiAction::TenantSuspend.as_str(), "tenant:Suspend");
+        assert_eq!(WamiAction::TenantResume.as_str(), "tenant:Resume");
         assert_eq!(WamiAction::TenantList.as_str(), "tenant:List");
     }
 
@@ -1881,7 +1900,7 @@ mod tests {
             (WamiServicePrefix::Platform, 4),
             // Douze : les sept d origine, plus les cinq qui vivaient sous
             // `space` et ne s en distinguaient pas.
-            (WamiServicePrefix::Tenant, 12),
+            (WamiServicePrefix::Tenant, 13),
             (WamiServicePrefix::Iam, 19),
             (WamiServicePrefix::Db, 9),
             (WamiServicePrefix::Chat, 4),
@@ -1919,6 +1938,6 @@ mod tests {
     fn registry_total_action_count() {
         let all = ActionRegistry::list_actions();
         // 4+8+7+19+9+4+6+6+4+4+6+3+5 = 85
-        assert_eq!(all.len(), 82);
+        assert_eq!(all.len(), 83);
     }
 }

--- a/crates/wami-core/src/actions.rs
+++ b/crates/wami-core/src/actions.rs
@@ -1,6 +1,6 @@
 //! WAMI Action vocabulary — the complete set of permissions for the obrain ecosystem.
 //!
-//! Each action follows the `service:Operation` convention (e.g. `"db:Query"`, `"space:Create"`).
+//! Each action follows the `service:Operation` convention (e.g. `"db:Query"`, `"tenant:Create"`).
 //! Special wildcards:
 //! - `"*"` matches ALL actions
 //! - `"service:*"` matches all actions within a service prefix
@@ -18,7 +18,6 @@ use std::sync::LazyLock;
 ///
 /// Actions are organized by service prefix:
 /// - `platform:*` — Platform-level administration
-/// - `space:*` — Space lifecycle and configuration
 /// - `tenant:*` — Tenant hierarchy management
 /// - `iam:*` — Identity & access management
 /// - `db:*` — Database / knowledge store operations
@@ -48,23 +47,17 @@ pub enum WamiAction {
     /// View platform audit logs
     PlatformViewAuditLog,
 
-    // -- space --------------------------------------------------------------
-    /// Create a new Space
-    SpaceCreate,
-    /// Delete a Space
-    SpaceDelete,
-    /// Read Space metadata
-    SpaceRead,
-    /// Update Space settings (branding, visibility, quotas)
-    SpaceUpdate,
-    /// Configure Space domain and port
-    SpaceConfigure,
-    /// Manage Space members (add, remove, ban)
-    SpaceManageMembers,
-    /// Suspend / reactivate a Space
-    SpaceSuspend,
-    /// List all Spaces (platform-level)
-    SpaceList,
+    // -- tenant -------------------------------------------------------------
+    /// Create a new tenant
+    TenantCreate,
+    /// Configure tenant domain and port
+    TenantConfigure,
+    /// Manage tenant members (add, remove, ban)
+    TenantManageMembers,
+    /// Suspend / reactivate a tenant
+    TenantSuspend,
+    /// List all tenants (platform-level)
+    TenantList,
 
     // -- tenant -------------------------------------------------------------
     /// Read tenant info
@@ -243,7 +236,6 @@ pub enum WamiAction {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum WamiServicePrefix {
     Platform,
-    Space,
     Tenant,
     Iam,
     Db,
@@ -261,7 +253,6 @@ impl WamiServicePrefix {
     pub fn as_str(&self) -> &'static str {
         match self {
             Self::Platform => "platform",
-            Self::Space => "space",
             Self::Tenant => "tenant",
             Self::Iam => "iam",
             Self::Db => "db",
@@ -279,7 +270,6 @@ impl WamiServicePrefix {
     pub fn all() -> &'static [WamiServicePrefix] {
         &[
             Self::Platform,
-            Self::Space,
             Self::Tenant,
             Self::Iam,
             Self::Db,
@@ -301,7 +291,6 @@ impl FromStr for WamiServicePrefix {
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
             "platform" => Ok(Self::Platform),
-            "space" => Ok(Self::Space),
             "tenant" => Ok(Self::Tenant),
             "iam" => Ok(Self::Iam),
             "db" => Ok(Self::Db),
@@ -342,7 +331,6 @@ impl WamiAction {
             Self::All => "*",
             Self::ServiceAll(prefix) => match prefix {
                 WamiServicePrefix::Platform => "platform:*",
-                WamiServicePrefix::Space => "space:*",
                 WamiServicePrefix::Tenant => "tenant:*",
                 WamiServicePrefix::Iam => "iam:*",
                 WamiServicePrefix::Db => "db:*",
@@ -360,15 +348,11 @@ impl WamiAction {
             Self::PlatformViewSettings => "platform:ViewSettings",
             Self::PlatformUpdateSettings => "platform:UpdateSettings",
             Self::PlatformViewAuditLog => "platform:ViewAuditLog",
-            // Space
-            Self::SpaceCreate => "space:Create",
-            Self::SpaceDelete => "space:Delete",
-            Self::SpaceRead => "space:Read",
-            Self::SpaceUpdate => "space:Update",
-            Self::SpaceConfigure => "space:Configure",
-            Self::SpaceManageMembers => "space:ManageMembers",
-            Self::SpaceSuspend => "space:Suspend",
-            Self::SpaceList => "space:List",
+            Self::TenantCreate => "tenant:Create",
+            Self::TenantConfigure => "tenant:Configure",
+            Self::TenantManageMembers => "tenant:ManageMembers",
+            Self::TenantSuspend => "tenant:Suspend",
+            Self::TenantList => "tenant:List",
             // Tenant
             Self::TenantRead => "tenant:Read",
             Self::TenantUpdate => "tenant:Update",
@@ -465,15 +449,12 @@ impl WamiAction {
             | Self::PlatformViewSettings
             | Self::PlatformUpdateSettings
             | Self::PlatformViewAuditLog => Some(WamiServicePrefix::Platform),
-            Self::SpaceCreate
-            | Self::SpaceDelete
-            | Self::SpaceRead
-            | Self::SpaceUpdate
-            | Self::SpaceConfigure
-            | Self::SpaceManageMembers
-            | Self::SpaceSuspend
-            | Self::SpaceList => Some(WamiServicePrefix::Space),
-            Self::TenantRead
+            Self::TenantCreate
+            | Self::TenantConfigure
+            | Self::TenantManageMembers
+            | Self::TenantSuspend
+            | Self::TenantList
+            | Self::TenantRead
             | Self::TenantUpdate
             | Self::TenantDelete
             | Self::TenantCreateSubTenant
@@ -595,16 +576,12 @@ impl FromStr for WamiAction {
             ("platform", "ViewSettings") => Ok(Self::PlatformViewSettings),
             ("platform", "UpdateSettings") => Ok(Self::PlatformUpdateSettings),
             ("platform", "ViewAuditLog") => Ok(Self::PlatformViewAuditLog),
-            // Space
-            ("space", "Create") => Ok(Self::SpaceCreate),
-            ("space", "Delete") => Ok(Self::SpaceDelete),
-            ("space", "Read") => Ok(Self::SpaceRead),
-            ("space", "Update") => Ok(Self::SpaceUpdate),
-            ("space", "Configure") => Ok(Self::SpaceConfigure),
-            ("space", "ManageMembers") => Ok(Self::SpaceManageMembers),
-            ("space", "Suspend") => Ok(Self::SpaceSuspend),
-            ("space", "List") => Ok(Self::SpaceList),
             // Tenant
+            ("tenant", "Create") => Ok(Self::TenantCreate),
+            ("tenant", "Configure") => Ok(Self::TenantConfigure),
+            ("tenant", "ManageMembers") => Ok(Self::TenantManageMembers),
+            ("tenant", "Suspend") => Ok(Self::TenantSuspend),
+            ("tenant", "List") => Ok(Self::TenantList),
             ("tenant", "Read") => Ok(Self::TenantRead),
             ("tenant", "Update") => Ok(Self::TenantUpdate),
             ("tenant", "Delete") => Ok(Self::TenantDelete),
@@ -817,20 +794,16 @@ static REGISTRY: LazyLock<Vec<ActionInfo>> = LazyLock::new(|| {
             "View platform audit logs",
             "platform",
         ),
-        // Space
-        ai("space:Create", "Create a new Space", "space"),
-        ai("space:Delete", "Delete a Space", "space"),
-        ai("space:Read", "Read Space metadata", "space"),
-        ai("space:Update", "Update Space settings", "space"),
-        ai(
-            "space:Configure",
-            "Configure Space domain and port",
-            "space",
-        ),
-        ai("space:ManageMembers", "Manage Space members", "space"),
-        ai("space:Suspend", "Suspend / reactivate a Space", "space"),
-        ai("space:List", "List all Spaces", "space"),
         // Tenant
+        ai("tenant:Create", "Create a new tenant", "tenant"),
+        ai(
+            "tenant:Configure",
+            "Configure tenant domain and port",
+            "tenant",
+        ),
+        ai("tenant:ManageMembers", "Manage tenant members", "tenant"),
+        ai("tenant:Suspend", "Suspend / reactivate a tenant", "tenant"),
+        ai("tenant:List", "List all tenants (platform-level)", "tenant"),
         ai("tenant:Read", "Read tenant info", "tenant"),
         ai("tenant:Update", "Update tenant", "tenant"),
         ai("tenant:Delete", "Delete tenant", "tenant"),
@@ -991,7 +964,7 @@ mod tests {
             WamiAction::All,
             WamiAction::ServiceAll(WamiServicePrefix::Db),
             WamiAction::PlatformAdmin,
-            WamiAction::SpaceCreate,
+            WamiAction::TenantCreate,
             WamiAction::TenantRead,
             WamiAction::IamCreateUser,
             WamiAction::DbQuery,
@@ -1094,15 +1067,11 @@ mod tests {
             WamiAction::PlatformViewSettings,
             WamiAction::PlatformUpdateSettings,
             WamiAction::PlatformViewAuditLog,
-            // Space
-            WamiAction::SpaceCreate,
-            WamiAction::SpaceDelete,
-            WamiAction::SpaceRead,
-            WamiAction::SpaceUpdate,
-            WamiAction::SpaceConfigure,
-            WamiAction::SpaceManageMembers,
-            WamiAction::SpaceSuspend,
-            WamiAction::SpaceList,
+            WamiAction::TenantCreate,
+            WamiAction::TenantConfigure,
+            WamiAction::TenantManageMembers,
+            WamiAction::TenantSuspend,
+            WamiAction::TenantList,
             // Tenant
             WamiAction::TenantRead,
             WamiAction::TenantUpdate,
@@ -1264,14 +1233,11 @@ mod tests {
                 WamiAction::PlatformViewAuditLog,
                 WamiServicePrefix::Platform,
             ),
-            (WamiAction::SpaceCreate, WamiServicePrefix::Space),
-            (WamiAction::SpaceDelete, WamiServicePrefix::Space),
-            (WamiAction::SpaceRead, WamiServicePrefix::Space),
-            (WamiAction::SpaceUpdate, WamiServicePrefix::Space),
-            (WamiAction::SpaceConfigure, WamiServicePrefix::Space),
-            (WamiAction::SpaceManageMembers, WamiServicePrefix::Space),
-            (WamiAction::SpaceSuspend, WamiServicePrefix::Space),
-            (WamiAction::SpaceList, WamiServicePrefix::Space),
+            (WamiAction::TenantCreate, WamiServicePrefix::Tenant),
+            (WamiAction::TenantConfigure, WamiServicePrefix::Tenant),
+            (WamiAction::TenantManageMembers, WamiServicePrefix::Tenant),
+            (WamiAction::TenantSuspend, WamiServicePrefix::Tenant),
+            (WamiAction::TenantList, WamiServicePrefix::Tenant),
             (WamiAction::TenantRead, WamiServicePrefix::Tenant),
             (WamiAction::TenantUpdate, WamiServicePrefix::Tenant),
             (WamiAction::TenantDelete, WamiServicePrefix::Tenant),
@@ -1411,18 +1377,15 @@ mod tests {
     }
 
     #[test]
-    fn as_str_space() {
-        assert_eq!(WamiAction::SpaceCreate.as_str(), "space:Create");
-        assert_eq!(WamiAction::SpaceDelete.as_str(), "space:Delete");
-        assert_eq!(WamiAction::SpaceRead.as_str(), "space:Read");
-        assert_eq!(WamiAction::SpaceUpdate.as_str(), "space:Update");
-        assert_eq!(WamiAction::SpaceConfigure.as_str(), "space:Configure");
+    fn as_str_tenant_lifecycle() {
+        assert_eq!(WamiAction::TenantCreate.as_str(), "tenant:Create");
+        assert_eq!(WamiAction::TenantConfigure.as_str(), "tenant:Configure");
         assert_eq!(
-            WamiAction::SpaceManageMembers.as_str(),
-            "space:ManageMembers"
+            WamiAction::TenantManageMembers.as_str(),
+            "tenant:ManageMembers"
         );
-        assert_eq!(WamiAction::SpaceSuspend.as_str(), "space:Suspend");
-        assert_eq!(WamiAction::SpaceList.as_str(), "space:List");
+        assert_eq!(WamiAction::TenantSuspend.as_str(), "tenant:Suspend");
+        assert_eq!(WamiAction::TenantList.as_str(), "tenant:List");
     }
 
     #[test]
@@ -1592,8 +1555,8 @@ mod tests {
             "platform:*"
         );
         assert_eq!(
-            WamiAction::ServiceAll(WamiServicePrefix::Space).as_str(),
-            "space:*"
+            WamiAction::ServiceAll(WamiServicePrefix::Tenant).as_str(),
+            "tenant:*"
         );
         assert_eq!(
             WamiAction::ServiceAll(WamiServicePrefix::Tenant).as_str(),
@@ -1720,8 +1683,8 @@ mod tests {
     #[test]
     fn matches_str_service_wildcard_every_prefix() {
         let prefixes_and_actions: Vec<(&str, &str, &str)> = vec![
-            ("platform:*", "platform:Admin", "space:Create"),
-            ("space:*", "space:Create", "tenant:Read"),
+            ("platform:*", "platform:Admin", "tenant:Create"),
+            ("platform:*", "platform:Admin", "tenant:Read"),
             ("tenant:*", "tenant:Read", "iam:CreateUser"),
             ("iam:*", "iam:CreateUser", "db:Query"),
             ("db:*", "db:Query", "chat:Send"),
@@ -1820,7 +1783,6 @@ mod tests {
     #[test]
     fn service_prefix_as_str_all() {
         assert_eq!(WamiServicePrefix::Platform.as_str(), "platform");
-        assert_eq!(WamiServicePrefix::Space.as_str(), "space");
         assert_eq!(WamiServicePrefix::Tenant.as_str(), "tenant");
         assert_eq!(WamiServicePrefix::Iam.as_str(), "iam");
         assert_eq!(WamiServicePrefix::Db.as_str(), "db");
@@ -1857,8 +1819,8 @@ mod tests {
     }
 
     #[test]
-    fn service_prefix_all_returns_all_13() {
-        assert_eq!(WamiServicePrefix::all().len(), 13);
+    fn service_prefix_all_returns_all_12() {
+        assert_eq!(WamiServicePrefix::all().len(), 12);
     }
 
     // -----------------------------------------------------------------------
@@ -1917,8 +1879,9 @@ mod tests {
     fn registry_list_by_every_prefix() {
         let expected_counts: Vec<(WamiServicePrefix, usize)> = vec![
             (WamiServicePrefix::Platform, 4),
-            (WamiServicePrefix::Space, 8),
-            (WamiServicePrefix::Tenant, 7),
+            // Douze : les sept d origine, plus les cinq qui vivaient sous
+            // `space` et ne s en distinguaient pas.
+            (WamiServicePrefix::Tenant, 12),
             (WamiServicePrefix::Iam, 19),
             (WamiServicePrefix::Db, 9),
             (WamiServicePrefix::Chat, 4),
@@ -1949,13 +1912,13 @@ mod tests {
     #[test]
     fn registry_list_prefixes() {
         let prefixes = ActionRegistry::list_prefixes();
-        assert_eq!(prefixes.len(), 13);
+        assert_eq!(prefixes.len(), 12);
     }
 
     #[test]
     fn registry_total_action_count() {
         let all = ActionRegistry::list_actions();
         // 4+8+7+19+9+4+6+6+4+4+6+3+5 = 85
-        assert_eq!(all.len(), 85);
+        assert_eq!(all.len(), 82);
     }
 }


### PR DESCRIPTION
The action vocabulary called the same object by two names. `TenantService`,
`TenantStore`, `TenantPath`, `TenantId` — the code has only ever said tenant.
`space` lived in exactly one file, `actions.rs`, and nowhere else in the
workspace: every other hit is `namespace` or `workspace`.

## It was not only a word

Three operations existed under both prefixes:

```
space:Read    and  tenant:Read
space:Update  and  tenant:Update
space:Delete  and  tenant:Delete
```

Two names for one operation is worse than a wrong name. A policy can allow one
and deny the other, both evaluate, and nothing says which was meant — the same
shape as a description reading *scoped* over a document saying
`Resource: ["*"]`, one layer down.

## The change

The three duplicates are gone. The five that existed only under `space` become
what they always were:

```
space:Create        → tenant:Create
space:Configure     → tenant:Configure
space:ManageMembers → tenant:ManageMembers
space:Suspend       → tenant:Suspend
space:List          → tenant:List
```

`WamiServicePrefix::Space` goes with them: **twelve** prefixes now, and
**eighty-two** actions rather than eighty-five.

`tenant:Create` is worth noticing on its own — **it did not exist**. The
registry had `space:Create` for the top-level thing and
`tenant:CreateSubTenant` for a child, so the verb depended on where in the tree
you stood.

## Left alone, deliberately

`tenant:CreateSubTenant` now sits beside `tenant:Create` and is arguably the
same verb with a parent — `tenant-tree` v6 already established that the ARN
pattern carries the scope (`tenant/1`, `tenant/1/*`, `tenant/1/**`), so *sub*
belongs in the resource rather than in the operation. Folding it is a second
decision with its own consequences, and it is not this one.

## Breaking, and quietly so

`space:*` no longer parses. `WamiAction::SpaceRead`, `SpaceUpdate` and
`SpaceDelete` are removed — use the `tenant:` equivalents, which already
existed — and the other five are renamed. `WamiServicePrefix::Space` is gone.

**Any stored policy naming a `space:` action stops matching**, and it stops
matching in silence: `matches_pattern` compares strings, so an Allow grants
nothing and a Deny denies nothing, with no error anywhere. Rewrite them before
upgrading. Nothing in this repository seeds such a policy any more — #137
removed the bootstrap that did — but a store initialised before that release
still holds `platform-space-creator` with `space:Create` in its document.

`cargo fmt`, `cargo clippy --workspace --all-targets` and the full suite
(942 + 368 + 176 + 52 doctests + the rest) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
