### PR TITLE
ci: run linked-versions before cargo-workspace, not after

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -73,7 +73,6 @@
   ],
   "separate-pull-requests": false,
   "plugins": [
-    "cargo-workspace",
     {
       "type": "linked-versions",
       "groupName": "wami",
@@ -83,6 +82,7 @@
         "wami-condition",
         "wami-macros"
       ]
-    }
+    },
+    "cargo-workspace"
   ]
 }


### PR DESCRIPTION
#139 added `cargo-workspace` and put it first. That was my choice and it was the wrong way round.

The first release through the repaired pipeline showed it, in the log:

```
✔ Running workspace plugin
❯ version: 0.17.1 forced bump
✔ Merging 5 in-scope candidates
❯ running plugin: LinkedVersions
```

`cargo-workspace` runs first and forces `wami` to `0.17.1` — a dependent bump, because wami-core changed under it. `linked-versions` then runs on candidates that are already merged and does not pull them back together. So **#144 proposes `wami 0.17.1` beside `wami-core 0.18.0`**, in a group configured to hold one number.

The other order composes: `linked-versions` raises all four to the highest computed version, then `cargo-workspace` rewrites the dependency declarations to match — and its forced bump for `wami` becomes a no-op, since 0.18.0 already exceeds the 0.17.1 it would ask for.

#139 was right about what was missing, only wrong about where it goes in the list.

**After this merges**, #144 should regenerate with all four at `0.18.0`. That is the thing to check before merging it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)