### PR TITLE
ci: drop linked-versions, which has never done anything

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -73,16 +73,6 @@
   ],
   "separate-pull-requests": false,
   "plugins": [
-    {
-      "type": "linked-versions",
-      "groupName": "wami",
-      "components": [
-        "wami",
-        "wami-core",
-        "wami-condition",
-        "wami-macros"
-      ]
-    },
     "cargo-workspace"
   ]
 }


### PR DESCRIPTION
Every run says the same line:

```
❯ running plugin: LinkedVersions
✔ found 0 linked-versions candidates
```

In both plugin orders, in every log available. The configuration declared that four crates move as one, and **nothing has ever honoured it**.

#145 claimed the order was the cause and merged on that reading. It was wrong — swapping them changed nothing, because the plugin matches no component either way. The change is harmless (order is immaterial to a plugin that finds nothing) but the reasoning does not hold, and this is the note that says so.

## What was read as incoherence is correct cargo semantics

```
wami-core      0.17.0 → 0.18.0    its API broke
wami-condition 0.17.0 → 0.18.0    same
wami-macros    0.17.0 → 0.18.0    same
wami           0.17.0 → 0.17.1    its API did not; its dependency did
```

A version says what changed in **that** crate, and `wami 0.17.1` depending on `wami-core 0.18.0` is a correct graph. `cargo-workspace` computed it and rewrote the declarations to match.

## So the config was the thing that was wrong

A declaration nothing implements is worse than its absence: it reads as a guarantee, and the next person to watch four versions diverge will go hunting for the bug that broke a rule which was never in force. This repository refuses that shape everywhere else — a column nothing reads, a description disagreeing with its document, a guard three paths walk past.

Linking them for real stays possible and is a separate question. The place to look is the component names in `components`, given `crates/wami` carries `include-component-in-tag: false` while the other three do not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)